### PR TITLE
Fix surah remote data source error

### DIFF
--- a/lib/data/datasource/surah/surah_remote_data_source.dart
+++ b/lib/data/datasource/surah/surah_remote_data_source.dart
@@ -22,7 +22,12 @@ class SurahRemoteDataSourceImpl implements SurahRemoteDataSource {
     if (response.statusCode == 200) {
       return ChapterResponse.fromJson(response.data);
     } else {
-      throw DioException;
+      throw DioException(
+        requestOptions: response.requestOptions,
+        response: response,
+        error: 'Unexpected status code: ${response.statusCode}',
+        type: DioExceptionType.badResponse,
+      );
     }
   }
 }

--- a/test/data/datasource/surah/surah_remote_data_source_test.dart
+++ b/test/data/datasource/surah/surah_remote_data_source_test.dart
@@ -58,8 +58,10 @@ void main() {
 
     test("make sure get surah return failure", () async {
       setUpMockDioFailed();
-      var result = await surahRemoteDataSource.getSurah("114");
-      expect(() => result, throwsA(const TypeMatcher<DioException>()));
+      expect(
+        () => surahRemoteDataSource.getSurah("114"),
+        throwsA(isA<DioException>()),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- handle non-200 responses by throwing a proper `DioException`
- expect exception correctly in surah data source test

## Testing
- `dart` and `flutter` were not available so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_687e4b70f058832ca0c2050a4e1f2497