### PR TITLE
Fix binding initialization and verse listener crash

### DIFF
--- a/lib/core/utils/size_utils.dart
+++ b/lib/core/utils/size_utils.dart
@@ -1,10 +1,9 @@
+import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 
 // This functions are responsible to make UI responsive across all the mobile devices.
 
-MediaQueryData mediaQueryData = MediaQueryData.fromView(
-  WidgetsBinding.instance.platformDispatcher.views.first,
-);
+MediaQueryData mediaQueryData = MediaQueryData.fromWindow(ui.window);
 
 // These are the Viewport values of your Figma Design.
 // These are used in the code as a reference to create your UI Responsively.

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -57,8 +57,9 @@ class _SurahScreenState extends State<SurahScreen>
           final positions = _itemPositionsListener.itemPositions.value;
           if (positions.isEmpty) return;
           // Index 0 is header; verses start at index 1
-          final min = positions
-              .where((p) => p.index >= 1)
+          final versePositions = positions.where((p) => p.index >= 1);
+          if (versePositions.isEmpty) return;
+          final min = versePositions
               .reduce((a, b) => a.index < b.index ? a : b)
               .index;
           final verseIndex = (min - 1).clamp(0, 10000);


### PR DESCRIPTION
## Summary
- avoid accessing WidgetsBinding before initialization
- guard empty positions list in verse index listener

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dc8e7980832c86b4aa035e7b4ed8