### PR TITLE
🔒 Move QRC API Key from URL to headers

### DIFF
--- a/lib/presentation/surah_screen/qrc_recitation_service.dart
+++ b/lib/presentation/surah_screen/qrc_recitation_service.dart
@@ -109,10 +109,11 @@ class QrcRecitationService {
       return false;
     }
 
-    final uri = Uri.parse(
-      '${ApiConfig.qrcWsBase}?api_key=${ApiConfig.qrcApiKey}',
+    final uri = Uri.parse(ApiConfig.qrcWsBase);
+    _channel = WebSocketChannel.connect(
+      uri,
+      protocols: ['x-api-key', ApiConfig.qrcApiKey],
     );
-    _channel = WebSocketChannel.connect(uri);
     _socketSub = _channel!.stream.listen(
       _handleSocketMessage,
       onError: (e) => _events.add(QrcErrorEvent(e.toString())),


### PR DESCRIPTION
### 🎯 What
The API key for the QRC (Qurani.ai) service was being passed as a query parameter in the WebSocket connection URL.

### ⚠️ Risk
API keys in URLs are frequently captured in server access logs, proxy logs, and browser history. If these logs are compromised or accessible to unauthorized personnel, the API key could be stolen and misused.

### 🛡️ Solution
I moved the API key from the URI query string to the WebSocket sub-protocol handshake mechanism. Specifically:
- Updated `lib/presentation/surah_screen/qrc_recitation_service.dart` to use a clean base URI.
- Passed the API key using the `protocols` parameter of `WebSocketChannel.connect`. 
- This uses the `Sec-WebSocket-Protocol` header for the transmission of the key, which is a standard security practice for cross-platform Flutter/Dart apps that must maintain web compatibility (as the web standard for WebSockets does not support custom headers).

---
*PR created automatically by Jules for task [12972622040581109063](https://jules.google.com/task/12972622040581109063) started by @moatazhamada*