### PR TITLE
refactor: separate QRC data concerns and secure API key transmission

### DIFF
--- a/lib/data/datasource/qrc/qrc_remote_datasource.dart
+++ b/lib/data/datasource/qrc/qrc_remote_datasource.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:web_socket_channel/web_socket_channel.dart';
+import '../../../core/config/api_config.dart';
+
+abstract class QrcRemoteDataSource {
+  Stream<dynamic> get events;
+  Future<void> connect();
+  void send(Map<String, dynamic> data);
+  void sendAudio(Uint8List data);
+  Future<void> disconnect();
+}
+
+class QrcRemoteDataSourceImpl implements QrcRemoteDataSource {
+  WebSocketChannel? _channel;
+  final StreamController<dynamic> _eventController = StreamController<dynamic>.broadcast();
+
+  @override
+  Stream<dynamic> get events => _eventController.stream;
+
+  @override
+  Future<void> connect() async {
+    if (_channel != null) return;
+
+    final uri = Uri.parse(ApiConfig.qrcWsBase);
+
+    // We send the API key as the first message after connection to avoid
+    // sub-protocol character constraints and keep the URL clean.
+    _channel = WebSocketChannel.connect(uri);
+
+    _channel!.stream.listen(
+      (message) => _eventController.add(message),
+      onError: (e) => _eventController.addError(e),
+      onDone: () {
+        _eventController.add('closed');
+        _channel = null;
+      },
+    );
+
+    // Authenticate immediately after connection
+    send({
+      'method': 'Authenticate',
+      'api_key': ApiConfig.qrcApiKey,
+    });
+  }
+
+  @override
+  void send(Map<String, dynamic> data) {
+    _channel?.sink.add(jsonEncode(data));
+  }
+
+  @override
+  void sendAudio(Uint8List data) {
+    _channel?.sink.add(data);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    await _channel?.sink.close();
+    _channel = null;
+  }
+}

--- a/lib/data/datasource/qrc/qrc_remote_datasource.dart
+++ b/lib/data/datasource/qrc/qrc_remote_datasource.dart
@@ -4,6 +4,10 @@ import 'dart:typed_data';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import '../../../core/config/api_config.dart';
 
+class QrcWsClosedEvent {
+  const QrcWsClosedEvent();
+}
+
 abstract class QrcRemoteDataSource {
   Stream<dynamic> get events;
   Future<void> connect();
@@ -14,10 +18,11 @@ abstract class QrcRemoteDataSource {
 
 class QrcRemoteDataSourceImpl implements QrcRemoteDataSource {
   WebSocketChannel? _channel;
-  final StreamController<dynamic> _eventController = StreamController<dynamic>.broadcast();
+  StreamController<dynamic>? _eventController =
+      StreamController<dynamic>.broadcast();
 
   @override
-  Stream<dynamic> get events => _eventController.stream;
+  Stream<dynamic> get events => _eventController!.stream;
 
   @override
   Future<void> connect() async {
@@ -25,24 +30,18 @@ class QrcRemoteDataSourceImpl implements QrcRemoteDataSource {
 
     final uri = Uri.parse(ApiConfig.qrcWsBase);
 
-    // We send the API key as the first message after connection to avoid
-    // sub-protocol character constraints and keep the URL clean.
     _channel = WebSocketChannel.connect(uri);
 
     _channel!.stream.listen(
-      (message) => _eventController.add(message),
-      onError: (e) => _eventController.addError(e),
+      (message) => _eventController?.add(message),
+      onError: (e) => _eventController?.addError(e),
       onDone: () {
-        _eventController.add('closed');
+        _eventController?.add(const QrcWsClosedEvent());
         _channel = null;
       },
     );
 
-    // Authenticate immediately after connection
-    send({
-      'method': 'Authenticate',
-      'api_key': ApiConfig.qrcApiKey,
-    });
+    send({'method': 'Authenticate', 'api_key': ApiConfig.qrcApiKey});
   }
 
   @override
@@ -59,5 +58,7 @@ class QrcRemoteDataSourceImpl implements QrcRemoteDataSource {
   Future<void> disconnect() async {
     await _channel?.sink.close();
     _channel = null;
+    await _eventController?.close();
+    _eventController = null;
   }
 }

--- a/lib/data/repository/qrc/qrc_repository_impl.dart
+++ b/lib/data/repository/qrc/qrc_repository_impl.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'package:hafiz_app/data/datasource/qrc/qrc_remote_datasource.dart';
+import 'package:hafiz_app/domain/repository/qrc/qrc_repository.dart';
+
+class QrcRepositoryImpl implements QrcRepository {
+  final QrcRemoteDataSource remoteDataSource;
+
+  QrcRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Stream<dynamic> get events => remoteDataSource.events;
+
+  @override
+  Future<void> connect() => remoteDataSource.connect();
+
+  @override
+  void subscribeCheckTilawa() {
+    remoteDataSource.send({'method': 'SubscribeCheckTilawa'});
+  }
+
+  @override
+  void startTilawaSession({
+    required int surahIndex,
+    required int verseIndex,
+    int wordIndex = 1,
+    int hafzLevel = 1,
+    int tajweedLevel = 3,
+  }) {
+    remoteDataSource.send({
+      'method': 'StartTilawaSession',
+      'chapter_index': surahIndex,
+      'verse_index': verseIndex,
+      'word_index': wordIndex,
+      'hafz_level': hafzLevel,
+      'tajweed_level': tajweedLevel,
+    });
+  }
+
+  @override
+  void sendAudio(Uint8List data) => remoteDataSource.sendAudio(data);
+
+  @override
+  Future<void> dispose() => remoteDataSource.disconnect();
+}

--- a/lib/domain/repository/qrc/qrc_repository.dart
+++ b/lib/domain/repository/qrc/qrc_repository.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+import 'dart:typed_data';
+import '../datasource/qrc/qrc_remote_datasource.dart';
+
+abstract class QrcRepository {
+  Stream<dynamic> get events;
+  Future<void> connect();
+  void subscribeCheckTilawa();
+  void startTilawaSession({
+    required int surahIndex,
+    required int verseIndex,
+    int wordIndex = 1,
+    int hafzLevel = 1,
+    int tajweedLevel = 3,
+  });
+  void sendAudio(Uint8List data);
+  Future<void> dispose();
+}
+
+class QrcRepositoryImpl implements QrcRepository {
+  final QrcRemoteDataSource remoteDataSource;
+
+  QrcRepositoryImpl({required this.remoteDataSource});
+
+  @override
+  Stream<dynamic> get events => remoteDataSource.events;
+
+  @override
+  Future<void> connect() => remoteDataSource.connect();
+
+  @override
+  void subscribeCheckTilawa() {
+    remoteDataSource.send({'method': 'SubscribeCheckTilawa'});
+  }
+
+  @override
+  void startTilawaSession({
+    required int surahIndex,
+    required int verseIndex,
+    int wordIndex = 1,
+    int hafzLevel = 1,
+    int tajweedLevel = 3,
+  }) {
+    remoteDataSource.send({
+      'method': 'StartTilawaSession',
+      'chapter_index': surahIndex,
+      'verse_index': verseIndex,
+      'word_index': wordIndex,
+      'hafz_level': hafzLevel,
+      'tajweed_level': tajweedLevel,
+    });
+  }
+
+  @override
+  void sendAudio(Uint8List data) => remoteDataSource.sendAudio(data);
+
+  @override
+  Future<void> dispose() => remoteDataSource.disconnect();
+}

--- a/lib/domain/repository/qrc/qrc_repository.dart
+++ b/lib/domain/repository/qrc/qrc_repository.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:typed_data';
-import '../datasource/qrc/qrc_remote_datasource.dart';
 
 abstract class QrcRepository {
   Stream<dynamic> get events;
@@ -15,45 +14,4 @@ abstract class QrcRepository {
   });
   void sendAudio(Uint8List data);
   Future<void> dispose();
-}
-
-class QrcRepositoryImpl implements QrcRepository {
-  final QrcRemoteDataSource remoteDataSource;
-
-  QrcRepositoryImpl({required this.remoteDataSource});
-
-  @override
-  Stream<dynamic> get events => remoteDataSource.events;
-
-  @override
-  Future<void> connect() => remoteDataSource.connect();
-
-  @override
-  void subscribeCheckTilawa() {
-    remoteDataSource.send({'method': 'SubscribeCheckTilawa'});
-  }
-
-  @override
-  void startTilawaSession({
-    required int surahIndex,
-    required int verseIndex,
-    int wordIndex = 1,
-    int hafzLevel = 1,
-    int tajweedLevel = 3,
-  }) {
-    remoteDataSource.send({
-      'method': 'StartTilawaSession',
-      'chapter_index': surahIndex,
-      'verse_index': verseIndex,
-      'word_index': wordIndex,
-      'hafz_level': hafzLevel,
-      'tajweed_level': tajweedLevel,
-    });
-  }
-
-  @override
-  void sendAudio(Uint8List data) => remoteDataSource.sendAudio(data);
-
-  @override
-  Future<void> dispose() => remoteDataSource.disconnect();
 }

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -27,6 +27,9 @@ import 'package:hafiz_app/data/repository/cloud_sync/cloud_sync_repository_impl.
 import 'package:hafiz_app/domain/repository/bookmark_repository.dart';
 import 'package:hafiz_app/domain/repository/recitation_error_repository.dart';
 import 'package:hafiz_app/domain/repository/cloud_sync_repository.dart';
+import 'package:hafiz_app/data/datasource/qrc/qrc_remote_datasource.dart';
+import 'package:hafiz_app/data/repository/qrc/qrc_repository_impl.dart';
+import 'package:hafiz_app/domain/repository/qrc/qrc_repository.dart';
 
 import 'core/network/network_manager.dart';
 import 'core/network/qf_auth.dart';
@@ -124,6 +127,14 @@ Future<void> init() async {
 
   sl.registerLazySingleton<CloudSyncRemoteDataSource>(
     () => CloudSyncRemoteDataSourceImpl(),
+  );
+
+  sl.registerLazySingleton<QrcRemoteDataSource>(
+    () => QrcRemoteDataSourceImpl(),
+  );
+
+  sl.registerLazySingleton<QrcRepository>(
+    () => QrcRepositoryImpl(remoteDataSource: sl()),
   );
 
   sl.registerLazySingleton(() => NetworkInfo(Connectivity()));

--- a/lib/localization/ar_eg/ar_eg_translations.dart
+++ b/lib/localization/ar_eg/ar_eg_translations.dart
@@ -199,4 +199,8 @@ final Map<String, String> arEg = {
       'الاسم وعد بشيء، لكنك ستحصل على شيء كلياً مختلف.',
   'musali_teaser_slide4_sub': 'فكر مجدداً.',
   'musali_teaser_slide4_sub_ar': 'فكر مجدداً.',
+
+  // QRC Errors
+  'msg_qrc_error': 'خطأ في التحقق من التلاوة',
+  'msg_qrc_invalid_message': 'رسالة تحقق غير صالحة',
 };

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -201,4 +201,8 @@ final Map<String, String> enUs = {
       'الاسم وعد بشيء، لكنك ستحصل على شيء كلياً مختلف.',
   'musali_teaser_slide4_sub': 'Think again.',
   'musali_teaser_slide4_sub_ar': 'فكر مجدداً.',
+
+  // QRC Errors
+  'msg_qrc_error': 'Recitation verification error',
+  'msg_qrc_invalid_message': 'Invalid recitation verification message',
 };

--- a/lib/presentation/surah_screen/qrc_recitation_service.dart
+++ b/lib/presentation/surah_screen/qrc_recitation_service.dart
@@ -2,9 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter_sound/flutter_sound.dart';
+import 'package:get_it/get_it.dart';
+import '../../core/app_export.dart';
 import '../../core/config/api_config.dart';
-import '../../domain/repository/qrc/qrc_repository.dart';
 import '../../data/datasource/qrc/qrc_remote_datasource.dart';
+import '../../data/repository/qrc/qrc_repository_impl.dart';
+import '../../domain/repository/qrc/qrc_repository.dart';
 
 class QrcTajweedMistake {
   final String? name;
@@ -102,27 +105,35 @@ class QrcRecitationService {
   StreamSubscription<Uint8List>? _audioSub;
 
   QrcRecitationService({QrcRepository? repository})
-      : _repository = repository ?? QrcRepositoryImpl(remoteDataSource: QrcRemoteDataSourceImpl());
+    : _repository = repository ?? _defaultRepository();
+
+  static QrcRepository _defaultRepository() {
+    try {
+      final sl = GetIt.instance;
+      if (sl.isRegistered<QrcRepository>()) return sl<QrcRepository>();
+    } catch (_) {}
+    return QrcRepositoryImpl(remoteDataSource: QrcRemoteDataSourceImpl());
+  }
 
   Stream<QrcEvent> get events => _events.stream;
 
   Future<bool> connect() async {
     if (ApiConfig.qrcApiKey.isEmpty) {
-      _events.add(QrcErrorEvent('Missing QRC API key'));
+      _events.add(QrcErrorEvent('msg_qrc_missing_key'.tr));
       return false;
     }
 
     try {
-      await _repository.connect();
       _repoSub = _repository.events.listen(
         _handleRepositoryMessage,
         onError: (e) => _events.add(QrcErrorEvent(e.toString())),
       );
+      await _repository.connect();
       _repository.subscribeCheckTilawa();
       _events.add(QrcStatusEvent('connected'));
       return true;
     } catch (e) {
-      _events.add(QrcErrorEvent(e.toString()));
+      _events.add(QrcErrorEvent('msg_qrc_error'.tr));
       return false;
     }
   }
@@ -170,7 +181,7 @@ class QrcRecitationService {
   }
 
   void _handleRepositoryMessage(dynamic message) {
-    if (message == 'closed') {
+    if (message is QrcWsClosedEvent) {
       _events.add(QrcStatusEvent('closed'));
       return;
     }
@@ -183,14 +194,16 @@ class QrcRecitationService {
           if (event == 'check_tilawa' || event == 'CheckTilawaResponse') {
             _events.add(QrcCheckEvent(QrcCheckTilawa.fromJson(json)));
           } else if (event == 'error') {
-            _events.add(QrcErrorEvent(json['message']?.toString() ?? 'QRC error'));
+            _events.add(
+              QrcErrorEvent(json['message']?.toString() ?? 'msg_qrc_error'.tr),
+            );
           } else if (event != null) {
             _events.add(QrcStatusEvent(event));
           }
         }
       }
     } catch (e) {
-      _events.add(QrcErrorEvent('Invalid QRC message: $e'));
+      _events.add(QrcErrorEvent('msg_qrc_invalid_message'.tr));
     }
   }
 

--- a/lib/presentation/surah_screen/qrc_recitation_service.dart
+++ b/lib/presentation/surah_screen/qrc_recitation_service.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter_sound/flutter_sound.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
-
 import '../../core/config/api_config.dart';
+import '../../domain/repository/qrc/qrc_repository.dart';
+import '../../data/datasource/qrc/qrc_remote_datasource.dart';
 
 class QrcTajweedMistake {
   final String? name;
@@ -94,12 +94,15 @@ class QrcErrorEvent extends QrcEvent {
 
 class QrcRecitationService {
   final FlutterSoundRecorder _recorder = FlutterSoundRecorder();
-  WebSocketChannel? _channel;
-  StreamSubscription? _socketSub;
+  final QrcRepository _repository;
+  StreamSubscription? _repoSub;
   final StreamController<QrcEvent> _events =
       StreamController<QrcEvent>.broadcast();
   StreamController<Uint8List>? _audioStreamController;
   StreamSubscription<Uint8List>? _audioSub;
+
+  QrcRecitationService({QrcRepository? repository})
+      : _repository = repository ?? QrcRepositoryImpl(remoteDataSource: QrcRemoteDataSourceImpl());
 
   Stream<QrcEvent> get events => _events.stream;
 
@@ -109,18 +112,19 @@ class QrcRecitationService {
       return false;
     }
 
-    final uri = Uri.parse(
-      '${ApiConfig.qrcWsBase}?api_key=${ApiConfig.qrcApiKey}',
-    );
-    _channel = WebSocketChannel.connect(uri);
-    _socketSub = _channel!.stream.listen(
-      _handleSocketMessage,
-      onError: (e) => _events.add(QrcErrorEvent(e.toString())),
-      onDone: () => _events.add(QrcStatusEvent('closed')),
-    );
-    _channel!.sink.add(jsonEncode({'method': 'SubscribeCheckTilawa'}));
-    _events.add(QrcStatusEvent('connected'));
-    return true;
+    try {
+      await _repository.connect();
+      _repoSub = _repository.events.listen(
+        _handleRepositoryMessage,
+        onError: (e) => _events.add(QrcErrorEvent(e.toString())),
+      );
+      _repository.subscribeCheckTilawa();
+      _events.add(QrcStatusEvent('connected'));
+      return true;
+    } catch (e) {
+      _events.add(QrcErrorEvent(e.toString()));
+      return false;
+    }
   }
 
   Future<void> startTilawaSession({
@@ -130,15 +134,13 @@ class QrcRecitationService {
     int hafzLevel = 1,
     int tajweedLevel = 3,
   }) async {
-    final payload = {
-      'method': 'StartTilawaSession',
-      'chapter_index': surahIndex,
-      'verse_index': verseIndex,
-      'word_index': wordIndex,
-      'hafz_level': hafzLevel,
-      'tajweed_level': tajweedLevel,
-    };
-    _channel?.sink.add(jsonEncode(payload));
+    _repository.startTilawaSession(
+      surahIndex: surahIndex,
+      verseIndex: verseIndex,
+      wordIndex: wordIndex,
+      hafzLevel: hafzLevel,
+      tajweedLevel: tajweedLevel,
+    );
   }
 
   Future<void> startRecording() async {
@@ -146,7 +148,7 @@ class QrcRecitationService {
     _audioStreamController = StreamController<Uint8List>();
     _audioSub = _audioStreamController!.stream.listen((data) {
       if (data.isNotEmpty) {
-        _channel?.sink.add(data);
+        _repository.sendAudio(data);
       }
     });
 
@@ -167,13 +169,18 @@ class QrcRecitationService {
     _audioStreamController = null;
   }
 
-  void _handleSocketMessage(dynamic message) {
+  void _handleRepositoryMessage(dynamic message) {
+    if (message == 'closed') {
+      _events.add(QrcStatusEvent('closed'));
+      return;
+    }
+
     try {
       if (message is String) {
         final json = jsonDecode(message);
         if (json is Map<String, dynamic>) {
           final event = json['event']?.toString();
-      if (event == 'check_tilawa' || event == 'CheckTilawaResponse') {
+          if (event == 'check_tilawa' || event == 'CheckTilawaResponse') {
             _events.add(QrcCheckEvent(QrcCheckTilawa.fromJson(json)));
           } else if (event == 'error') {
             _events.add(QrcErrorEvent(json['message']?.toString() ?? 'QRC error'));
@@ -190,8 +197,8 @@ class QrcRecitationService {
   Future<void> dispose() async {
     await stopRecording();
     await _recorder.closeRecorder();
-    await _socketSub?.cancel();
+    await _repoSub?.cancel();
     await _events.close();
-    await _channel?.sink.close();
+    await _repository.dispose();
   }
 }


### PR DESCRIPTION
- Introduced `QrcRemoteDataSource` and `QrcRepository` to isolate external WebSocket I/O from the presentation layer, adhering to Clean Architecture principles.
- Switched from passing the API key in the URL/sub-protocols to sending it as an 'Authenticate' message after the connection is established. This prevents exposure in logs and avoids handshake failures due to invalid protocol characters.