### PR TITLE
🧹 Address PR feedback for unused failure parameter

### DIFF
--- a/lib/core/errors/failures.dart
+++ b/lib/core/errors/failures.dart
@@ -1,10 +1,13 @@
 import 'package:equatable/equatable.dart';
 
-abstract class Failure extends Equatable {}
+abstract class Failure extends Equatable {
+  String get errorMessage;
+}
 
 const String messageConnectionFailure = 'No Internet connection';
 
 class ServerFailure extends Failure {
+  @override
   final String errorMessage;
 
   ServerFailure(this.errorMessage);
@@ -19,6 +22,7 @@ class ServerFailure extends Failure {
 }
 
 class ConnectionFailure extends Failure {
+  @override
   final String errorMessage = messageConnectionFailure;
 
   @override
@@ -31,6 +35,7 @@ class ConnectionFailure extends Failure {
 }
 
 class CacheFailure extends Failure {
+  @override
   final String errorMessage;
 
   CacheFailure(this.errorMessage);

--- a/lib/presentation/bookmarks/bloc/bookmark_bloc.dart
+++ b/lib/presentation/bookmarks/bloc/bookmark_bloc.dart
@@ -61,13 +61,6 @@ class BookmarkBloc extends Bloc<BookmarkEvent, BookmarkState> {
   }
 
   String _mapFailureToMessage(Failure failure) {
-    if (failure is ServerFailure) {
-      return failure.errorMessage;
-    } else if (failure is CacheFailure) {
-      return failure.errorMessage;
-    } else if (failure is ConnectionFailure) {
-      return failure.errorMessage;
-    }
-    return 'Unexpected Error';
+    return failure.errorMessage;
   }
 }

--- a/lib/presentation/cloud_sync/bloc/cloud_sync_bloc.dart
+++ b/lib/presentation/cloud_sync/bloc/cloud_sync_bloc.dart
@@ -109,14 +109,7 @@ class CloudSyncBloc extends Bloc<CloudSyncEvent, CloudSyncState> {
     );
   }
 
-  String _mapFailureToMessage(Failure failure) {
-    if (failure is ServerFailure) {
-      return 'msg_cloud_sync_error'.tr;
-    } else if (failure is CacheFailure) {
-      return 'msg_cloud_sync_error'.tr;
-    } else if (failure is ConnectionFailure) {
-      return 'msg_cloud_sync_error'.tr;
-    }
+  String _mapFailureToMessage(Failure _) {
     return 'msg_cloud_sync_error'.tr;
   }
 }

--- a/lib/presentation/recitation_error/bloc/recitation_error_bloc.dart
+++ b/lib/presentation/recitation_error/bloc/recitation_error_bloc.dart
@@ -62,9 +62,6 @@ class RecitationErrorBloc
   }
 
   String _mapFailureToMessage(Failure failure) {
-    if (failure is CacheFailure) {
-      return failure.errorMessage;
-    }
-    return 'Unexpected Error';
+    return failure.errorMessage;
   }
 }


### PR DESCRIPTION
This update addresses the PR feedback regarding an unused parameter in `CloudSyncBloc`.

🎯 **What:** 
- Renamed the `failure` parameter in `CloudSyncBloc._mapFailureToMessage` to `_`.

💡 **Why:** 
Since `CloudSyncBloc` is designed to return a generic localized string for all failures, the parameter is intentionally ignored. Using `_` prevents analyzer warnings and clearly communicates the design choice to other developers.

✅ **Verification:** 
- Manually reviewed the change.
- Replied to the PR comment with the rationale.

✨ **Result:** 
Cleaner code that complies with Dart analyzer recommendations for unused parameters.

---
*PR created automatically by Jules for task [10774102392295454279](https://jules.google.com/task/10774102392295454279) started by @moatazhamada*