### PR TITLE
🌐 Localize failure-to-message mapping in blocs

### DIFF
--- a/lib/localization/ar_eg/ar_eg_translations.dart
+++ b/lib/localization/ar_eg/ar_eg_translations.dart
@@ -236,6 +236,12 @@ final Map<String, String> arEg = {
   'musali_teaser_slide4_sub': 'فكر مجدداً.',
   'musali_teaser_slide4_sub_ar': 'فكر مجدداً.',
 
+  // Failure Messages
+  'msg_server_error': 'حدث خطأ في الخادم',
+  'msg_cache_error': 'خطأ في البيانات المحلية',
+  'msg_connection_error': 'لا يوجد اتصال بالإنترنت',
+  'msg_unexpected_error': 'خطأ غير متوقع',
+
   // QRC Errors
   'msg_qrc_error': 'خطأ في التحقق من التلاوة',
   'msg_qrc_invalid_message': 'رسالة تحقق غير صالحة',

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -239,6 +239,12 @@ final Map<String, String> enUs = {
   'musali_teaser_slide4_sub': 'Think again.',
   'musali_teaser_slide4_sub_ar': 'فكر مجدداً.',
 
+  // Failure Messages
+  'msg_server_error': 'Server error occurred',
+  'msg_cache_error': 'Local data error',
+  'msg_connection_error': 'No Internet connection',
+  'msg_unexpected_error': 'Unexpected error',
+
   // QRC Errors
   'msg_qrc_error': 'Recitation verification error',
   'msg_qrc_invalid_message': 'Invalid recitation verification message',

--- a/lib/presentation/bookmarks/bloc/bookmark_bloc.dart
+++ b/lib/presentation/bookmarks/bloc/bookmark_bloc.dart
@@ -62,12 +62,12 @@ class BookmarkBloc extends Bloc<BookmarkEvent, BookmarkState> {
 
   String _mapFailureToMessage(Failure failure) {
     if (failure is ServerFailure) {
-      return failure.errorMessage;
+      return 'msg_server_error';
     } else if (failure is CacheFailure) {
-      return failure.errorMessage;
+      return 'msg_cache_error';
     } else if (failure is ConnectionFailure) {
-      return failure.errorMessage;
+      return 'msg_connection_error';
     }
-    return 'Unexpected Error';
+    return 'msg_unexpected_error';
   }
 }

--- a/lib/presentation/bookmarks/bookmarks_screen.dart
+++ b/lib/presentation/bookmarks/bookmarks_screen.dart
@@ -50,7 +50,7 @@ class BookmarksScreen extends StatelessWidget {
           } else if (state is BookmarkError) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: Text('${"msg_error_prefix".tr}${state.message}'),
+                content: Text('${"msg_error_prefix".tr}${state.message.tr}'),
               ),
             );
           }
@@ -244,7 +244,7 @@ class BookmarksScreen extends StatelessWidget {
               child: Semantics(
                 liveRegion: true,
                 child: Text(
-                  '${'lbl_error'.tr}: ${state.message}',
+                  '${'lbl_error'.tr}: ${state.message.tr}',
                   style: TextStyle(
                     color: isDark ? Colors.redAccent : Colors.red,
                   ),

--- a/lib/presentation/recitation_error/bloc/recitation_error_bloc.dart
+++ b/lib/presentation/recitation_error/bloc/recitation_error_bloc.dart
@@ -63,8 +63,8 @@ class RecitationErrorBloc
 
   String _mapFailureToMessage(Failure failure) {
     if (failure is CacheFailure) {
-      return failure.errorMessage;
+      return 'msg_cache_error';
     }
-    return 'Unexpected Error';
+    return 'msg_unexpected_error';
   }
 }

--- a/lib/presentation/recitation_error/recitation_error_screen.dart
+++ b/lib/presentation/recitation_error/recitation_error_screen.dart
@@ -210,7 +210,9 @@ class RecitationErrorScreen extends StatelessWidget {
               },
             );
           } else if (state is RecitationErrorError) {
-            return Center(child: Text('Error: ${state.message}'));
+            return Center(
+              child: Text('${"lbl_error".tr}: ${state.message.tr}'),
+            );
           }
           return const SizedBox();
         },

--- a/lib/presentation/surah_screen/bloc/surah_bloc.dart
+++ b/lib/presentation/surah_screen/bloc/surah_bloc.dart
@@ -27,9 +27,9 @@ class SurahBloc extends Bloc<SurahEvent, SurahState> {
       emit(
         response.fold((failure) {
           if (failure is ServerFailure) {
-            return FailureSurahState(errorMessage: failure.errorMessage);
+            return FailureSurahState(errorMessage: 'msg_server_error');
           } else if (failure is ConnectionFailure) {
-            return FailureSurahState(errorMessage: failure.errorMessage);
+            return FailureSurahState(errorMessage: 'msg_connection_error');
           } else {
             return InitialSurahState();
           }

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -551,7 +551,7 @@ class _SurahScreenState extends State<SurahScreen> {
                     return Center(
                       child: Semantics(
                         liveRegion: true,
-                        child: Text(state.errorMessage),
+                        child: Text(state.errorMessage.tr),
                       ),
                     );
                   } else {


### PR DESCRIPTION
## Summary
- Return localization keys instead of raw `failure.errorMessage` (hardcoded English) in `BookmarkBloc`, `RecitationErrorBloc`, and `SurahBloc`
- Add `.tr` calls in UI screens where error messages are displayed (`bookmarks_screen.dart`, `recitation_error_screen.dart`, `surah_screen.dart`)
- Add new localized keys (`msg_server_error`, `msg_cache_error`, `msg_connection_error`, `msg_unexpected_error`) to both `en_US` and `ar_EG` translations

## Context
Addresses the PR #28 feedback (which was closed due to deleted branch). The `_mapFailureToMessage` methods were returning raw English strings from `failure.errorMessage`, which would not be translated when the user switches to Arabic.

## Test Plan
- [x] `flutter analyze` — no new issues
- [x] All tests pass (97/98 — the 1 failure is pre-existing in `cloud_sync_bloc_test`)
- [x] Follows existing pattern: bloc returns localization key, UI applies `.tr` (same as `msg_bookmark_added`, etc.)