### PR TITLE
🧹 Promote errorMessage to Failure base class and simplify CloudSyncBloc

### DIFF
--- a/lib/core/errors/failures.dart
+++ b/lib/core/errors/failures.dart
@@ -1,10 +1,13 @@
 import 'package:equatable/equatable.dart';
 
-abstract class Failure extends Equatable {}
+abstract class Failure extends Equatable {
+  String get errorMessage;
+}
 
 const String messageConnectionFailure = 'No Internet connection';
 
 class ServerFailure extends Failure {
+  @override
   final String errorMessage;
 
   ServerFailure(this.errorMessage);
@@ -19,6 +22,7 @@ class ServerFailure extends Failure {
 }
 
 class ConnectionFailure extends Failure {
+  @override
   final String errorMessage = messageConnectionFailure;
 
   @override
@@ -31,6 +35,7 @@ class ConnectionFailure extends Failure {
 }
 
 class CacheFailure extends Failure {
+  @override
   final String errorMessage;
 
   CacheFailure(this.errorMessage);

--- a/lib/presentation/cloud_sync/bloc/cloud_sync_bloc.dart
+++ b/lib/presentation/cloud_sync/bloc/cloud_sync_bloc.dart
@@ -107,14 +107,7 @@ class CloudSyncBloc extends Bloc<CloudSyncEvent, CloudSyncState> {
     );
   }
 
-  String _mapFailureToMessage(Failure failure) {
-    if (failure is ServerFailure) {
-      return 'msg_cloud_sync_error'.tr;
-    } else if (failure is CacheFailure) {
-      return 'msg_cloud_sync_error'.tr;
-    } else if (failure is ConnectionFailure) {
-      return 'msg_cloud_sync_error'.tr;
-    }
+  String _mapFailureToMessage(Failure _) {
     return 'msg_cloud_sync_error'.tr;
   }
 }


### PR DESCRIPTION
## Summary
- Promotes `errorMessage` as an abstract getter on the `Failure` base class, with `@override` on all three subclasses. This was the core improvement from PR #28.
- Simplifies `CloudSyncBloc._mapFailureToMessage` — all branches returned the same `'msg_cloud_sync_error'.tr`, so collapsed to a single return with unused param renamed to `_`.

## What about PR #28?
PR #28's branch was restored by @moatazhamada. This PR absorbs the valid parts of it:
- **Base class promotion**: ✅ included
- **CloudSyncBloc simplification**: ✅ included  
- **BookmarkBloc / RecitationErrorBloc simplification**: ❌ not included — PR #32 already improved these to return *different* localized keys per failure type (e.g., `msg_server_error` vs `msg_cache_error`), which is more user-friendly than collapsing to `failure.errorMessage`.

After this merges, PR #28 can be closed.

## Test Plan
- [x] `flutter analyze` — no new issues
- [x] 97/98 tests pass (1 pre-existing failure in `cloud_sync_bloc_test`)