### PR TITLE
⚡ Bolt: Refactor duplicate state filtering to O(1) lookups via Dart Records

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Avoid Duplicate O(N) Set Computations in Build Methods]
+**Learning:** Pre-calculating `Set.contains()` is important for rendering loops to avoid O(N*M) lookups. However, computing these sets redundantly within different build methods (like rich text vs single line modes) duplicates O(N) filtering operations on state arrays. The codebase convention uses Dart Records to group these lookups via private helper methods.
+**Action:** Extract multiple O(N) state-to-Set conversions into a single helper method returning a Dart Record to maintain performance and maintainability across different view modes.

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -1129,6 +1129,26 @@ class _SurahScreenState extends State<SurahScreen> {
     }
   }
 
+  ({Set<int> bookmarkedVerses, Set<int> errorVerses}) _getVerseStates(
+    BookmarkState bookmarkState,
+    RecitationErrorState errorState,
+  ) {
+    final surahId = surah?.id ?? -1;
+    final bookmarkedVerses = bookmarkState is BookmarkLoaded
+        ? bookmarkState.bookmarks
+            .where((b) => b.surahId == surahId)
+            .map((b) => b.verseNumber)
+            .toSet()
+        : <int>{};
+    final errorVerses = errorState is RecitationErrorLoaded
+        ? errorState.errors
+            .where((m) => m.surahId == surahId)
+            .map((m) => m.verseId)
+            .toSet()
+        : <int>{};
+    return (bookmarkedVerses: bookmarkedVerses, errorVerses: errorVerses);
+  }
+
   Widget _buildSurahList(
     BuildContext context,
     List<Verse> chapters,
@@ -1177,38 +1197,15 @@ class _SurahScreenState extends State<SurahScreen> {
     final badgeText = colors.badgeText;
     final badgeGradient = colors.badgeGradient;
 
-    final surahId = surah?.id ?? -1;
-    final bookmarkedVerses = bookmarkState is BookmarkLoaded
-        ? bookmarkState.bookmarks
-              .where((b) => b.surahId == surahId)
-              .map((b) => b.verseNumber)
-              .toSet()
-        : <int>{};
-    final errorVerses = errorState is RecitationErrorLoaded
-        ? errorState.errors
-              .where((m) => m.surahId == surahId)
-              .map((m) => m.verseId)
-              .toSet()
-        : <int>{};
+    final verseStates = _getVerseStates(bookmarkState, errorState);
+    final bookmarkedVerseNumbers = verseStates.bookmarkedVerses;
+    final errorVerseIds = verseStates.errorVerses;
 
     List<InlineSpan> spans = [];
     final List<_VerseRange> verseRanges = [];
     int currentOffset = 0;
 
     _currentVerseRanges = verseRanges;
-
-    final Set<int> bookmarkedVerseNumbers = bookmarkState is BookmarkLoaded
-        ? bookmarkState.bookmarks
-              .where((b) => b.surahId == (surah?.id ?? -1))
-              .map((b) => b.verseNumber)
-              .toSet()
-        : {};
-    final Set<int> errorVerseIds = errorState is RecitationErrorLoaded
-        ? errorState.errors
-              .where((m) => m.surahId == (surah?.id ?? -1))
-              .map((m) => m.verseId)
-              .toSet()
-        : {};
 
     for (var aya in chapters) {
       bool isBookmarked = bookmarkedVerseNumbers.contains(aya.verseNumber);
@@ -1443,32 +1440,9 @@ class _SurahScreenState extends State<SurahScreen> {
     final badgeText = colors.badgeText;
     final badgeGradient = colors.badgeGradient;
 
-    final surahId = surah?.id ?? -1;
-    final bookmarkedVerses = bookmarkState is BookmarkLoaded
-        ? bookmarkState.bookmarks
-              .where((b) => b.surahId == surahId)
-              .map((b) => b.verseNumber)
-              .toSet()
-        : <int>{};
-    final errorVerses = errorState is RecitationErrorLoaded
-        ? errorState.errors
-              .where((m) => m.surahId == surahId)
-              .map((m) => m.verseId)
-              .toSet()
-        : <int>{};
-
-    final Set<int> bookmarkedVerseNumbers = bookmarkState is BookmarkLoaded
-        ? bookmarkState.bookmarks
-              .where((b) => b.surahId == (surah?.id ?? -1))
-              .map((b) => b.verseNumber)
-              .toSet()
-        : {};
-    final Set<int> errorVerseIds = errorState is RecitationErrorLoaded
-        ? errorState.errors
-              .where((m) => m.surahId == (surah?.id ?? -1))
-              .map((m) => m.verseId)
-              .toSet()
-        : {};
+    final verseStates = _getVerseStates(bookmarkState, errorState);
+    final bookmarkedVerseNumbers = verseStates.bookmarkedVerses;
+    final errorVerseIds = verseStates.errorVerses;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,


### PR DESCRIPTION
💡 What: Refactored `_buildRichTextContent` and `_buildSingleLineContent` in `SurahScreen` to use a single helper method `_getVerseStates` that returns a Dart Record containing the `Set`s for `bookmarkedVerses` and `errorVerses`.
🎯 Why: Avoids duplicate O(N) operations and memory allocations during rendering loops. The sets were being computed multiple times unnecessarily.
📊 Impact: Speeds up UI rendering marginally by eliminating redundant array traversals on every build.
🔬 Measurement: Verified the code compiles correctly and runs without introducing new regressions, maintaining the application's stability. All related tests pass.

---
*PR created automatically by Jules for task [7679397878628271838](https://jules.google.com/task/7679397878628271838) started by @moatazhamada*