### PR TITLE
feat: add mushaf screen with horizontal page view

### DIFF
--- a/lib/core/quran_index/mushaf_page_index.dart
+++ b/lib/core/quran_index/mushaf_page_index.dart
@@ -1,0 +1,236 @@
+class MushafPageRange {
+  final int startVerse;
+  final int endVerse;
+
+  const MushafPageRange({required this.startVerse, required this.endVerse});
+}
+
+class MushafPageData {
+  final int surahId;
+  final String surahNameArabic;
+  final String surahNameEnglish;
+  final MushafPageRange? juzStart;
+  final MushafPageRange? range;
+
+  const MushafPageData({
+    required this.surahId,
+    required this.surahNameArabic,
+    required this.surahNameEnglish,
+    this.juzStart,
+    this.range,
+  });
+}
+
+class MushafPageIndex {
+  static const int totalPages = 604;
+
+  static const List<int> _surahStartPages = [
+    1,
+    2,
+    21,
+    50,
+    77,
+    106,
+    128,
+    142,
+    151,
+    158,
+    177,
+    187,
+    206,
+    208,
+    224,
+    227,
+    242,
+    249,
+    255,
+    266,
+    281,
+    282,
+    293,
+    305,
+    312,
+    322,
+    331,
+    342,
+    350,
+    360,
+    364,
+    367,
+    370,
+    377,
+    382,
+    386,
+    393,
+    399,
+    404,
+    410,
+    414,
+    418,
+    420,
+    423,
+    426,
+    428,
+    432,
+    434,
+    440,
+    446,
+    448,
+    450,
+    452,
+    454,
+    456,
+    459,
+    462,
+    465,
+    468,
+    472,
+    475,
+    477,
+    479,
+    482,
+    484,
+    486,
+    489,
+    492,
+    496,
+    499,
+    501,
+    503,
+    504,
+    506,
+    508,
+    510,
+    512,
+    514,
+    516,
+    518,
+    519,
+    520,
+    522,
+    523,
+    525,
+    527,
+    529,
+    530,
+    531,
+    533,
+    534,
+    536,
+    538,
+    539,
+    541,
+    542,
+    544,
+    545,
+    547,
+    549,
+    550,
+    551,
+    553,
+    554,
+    556,
+    558,
+    560,
+    561,
+    562,
+    564,
+    566,
+    568,
+    570,
+    571,
+    572,
+    574,
+    575,
+    577,
+    578,
+    580,
+  ];
+
+  static int getSurahForPage(int page) {
+    if (page < 1 || page > totalPages) return 1;
+    for (int i = _surahStartPages.length - 1; i >= 0; i--) {
+      if (_surahStartPages[i] <= page) return i + 1;
+    }
+    return 1;
+  }
+
+  static int getPageForSurah(int surahId) {
+    if (surahId < 1 || surahId > 114) return 1;
+    return _surahStartPages[surahId - 1];
+  }
+
+  static int getSurahForJuz(int juz) {
+    if (juz < 1 || juz > 30) return 1;
+    const juzSurahs = [
+      1,
+      2,
+      2,
+      3,
+      4,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      11,
+      12,
+      15,
+      17,
+      18,
+      21,
+      23,
+      25,
+      27,
+      29,
+      33,
+      36,
+      39,
+      41,
+      46,
+      51,
+      58,
+      67,
+      78,
+    ];
+    return juzSurahs[juz - 1];
+  }
+
+  static int getPageForJuz(int juz) {
+    if (juz < 1 || juz > 30) return 1;
+    const juzPages = [
+      1,
+      21,
+      42,
+      62,
+      82,
+      106,
+      127,
+      151,
+      177,
+      187,
+      208,
+      224,
+      249,
+      255,
+      266,
+      282,
+      293,
+      305,
+      322,
+      342,
+      360,
+      382,
+      399,
+      414,
+      426,
+      440,
+      452,
+      468,
+      486,
+      516,
+    ];
+    return juzPages[juz - 1];
+  }
+}

--- a/lib/localization/ar_eg/ar_eg_translations.dart
+++ b/lib/localization/ar_eg/ar_eg_translations.dart
@@ -245,4 +245,10 @@ final Map<String, String> arEg = {
   // QRC Errors
   'msg_qrc_error': 'خطأ في التحقق من التلاوة',
   'msg_qrc_invalid_message': 'رسالة تحقق غير صالحة',
+
+  // Mushaf Screen
+  'lbl_mushaf': 'المصحف',
+  'lbl_jump_to_page': 'الانتقال لصفحة',
+  'lbl_page': 'صفحة',
+  'lbl_go': 'اذهب',
 };

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -248,4 +248,10 @@ final Map<String, String> enUs = {
   // QRC Errors
   'msg_qrc_error': 'Recitation verification error',
   'msg_qrc_invalid_message': 'Invalid recitation verification message',
+
+  // Mushaf Screen
+  'lbl_mushaf': 'Mushaf',
+  'lbl_jump_to_page': 'Jump to Page',
+  'lbl_page': 'Page',
+  'lbl_go': 'Go',
 };

--- a/lib/presentation/mushaf_screen/mushaf_screen.dart
+++ b/lib/presentation/mushaf_screen/mushaf_screen.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import '../../core/app_export.dart';
+import '../../core/quran_index/mushaf_page_index.dart';
+import '../../core/quran_index/quran_surah.dart';
+
+class MushafScreen extends StatefulWidget {
+  final int initialPage;
+
+  const MushafScreen({super.key, this.initialPage = 1});
+
+  @override
+  State<MushafScreen> createState() => _MushafScreenState();
+}
+
+class _MushafScreenState extends State<MushafScreen> {
+  late PageController _pageController;
+  late int _currentPage;
+  bool _showPageInput = false;
+  final TextEditingController _pageInputController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _currentPage = widget.initialPage.clamp(1, MushafPageIndex.totalPages);
+    _pageController = PageController(initialPage: _currentPage - 1);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    _pageInputController.dispose();
+    super.dispose();
+  }
+
+  void _goToPage(int page) {
+    final target = page.clamp(1, MushafPageIndex.totalPages);
+    _pageController.animateToPage(
+      target - 1,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _showJumpDialog() {
+    _pageInputController.text = _currentPage.toString();
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('lbl_jump_to_page'.tr),
+        content: TextField(
+          controller: _pageInputController,
+          keyboardType: TextInputType.number,
+          autofocus: true,
+          decoration: InputDecoration(
+            labelText: 'lbl_page'.tr,
+            hintText: '1 - ${MushafPageIndex.totalPages}',
+          ),
+          onSubmitted: (value) {
+            final page = int.tryParse(value) ?? _currentPage;
+            Navigator.pop(context);
+            _goToPage(page);
+          },
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text('lbl_cancel'.tr),
+          ),
+          TextButton(
+            onPressed: () {
+              final page =
+                  int.tryParse(_pageInputController.text) ?? _currentPage;
+              Navigator.pop(context);
+              _goToPage(page);
+            },
+            child: Text('lbl_go'.tr),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final isArabic = Localizations.localeOf(context).languageCode == 'ar';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('lbl_mushaf'.tr),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.keyboard_return),
+            onPressed: _showJumpDialog,
+            tooltip: 'lbl_jump_to_page'.tr,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView.builder(
+              controller: _pageController,
+              reverse: true,
+              itemCount: MushafPageIndex.totalPages,
+              onPageChanged: (index) {
+                setState(() {
+                  _currentPage = index + 1;
+                });
+              },
+              itemBuilder: (context, index) {
+                final pageNumber = index + 1;
+                final surahId = MushafPageIndex.getSurahForPage(pageNumber);
+                final surah = QuranIndex.quranSurahs[surahId - 1];
+
+                return _buildMushafPage(
+                  context,
+                  theme,
+                  isDark,
+                  isArabic,
+                  pageNumber,
+                  surah,
+                );
+              },
+            ),
+          ),
+          _buildPageIndicator(theme, isDark),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMushafPage(
+    BuildContext context,
+    ThemeData theme,
+    bool isDark,
+    bool isArabic,
+    int pageNumber,
+    Surah surah,
+  ) {
+    return GestureDetector(
+      onDoubleTap: _showJumpDialog,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1A1A2E) : const Color(0xFFFFFBF0),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: isDark ? Colors.white12 : Colors.brown.shade200,
+            width: 0.5,
+          ),
+        ),
+        child: Stack(
+          children: [
+            Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    surah.nameArabic,
+                    style: TextStyle(
+                      fontFamily: 'Amiri',
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                      color: isDark ? Colors.white70 : Colors.black87,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    isArabic ? surah.nameArabic : surah.nameEnglish,
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: isDark ? Colors.white54 : Colors.black54,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  Icon(
+                    Icons.menu_book_rounded,
+                    size: 64,
+                    color: isDark ? Colors.white24 : Colors.brown.shade100,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    '$pageNumber / ${MushafPageIndex.totalPages}',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: isDark ? Colors.white38 : Colors.black38,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Positioned(
+              top: 8,
+              right: 12,
+              child: Text(
+                pageNumber.toString(),
+                style: TextStyle(
+                  fontSize: 12,
+                  color: isDark ? Colors.white38 : Colors.black38,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPageIndicator(ThemeData theme, bool isDark) {
+    final surahId = MushafPageIndex.getSurahForPage(_currentPage);
+    final surah = QuranIndex.quranSurahs[surahId - 1];
+    final isArabic = Localizations.localeOf(context).languageCode == 'ar';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: theme.scaffoldBackgroundColor,
+        border: Border(top: BorderSide(color: theme.dividerColor, width: 0.5)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              isArabic ? surah.nameArabic : surah.nameEnglish,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            GestureDetector(
+              onTap: _showJumpDialog,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 4,
+                ),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Text(
+                  '${'lbl_page'.tr} $_currentPage',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -14,6 +14,7 @@ import '../presentation/khatmah/khatmah_screen.dart';
 import '../presentation/settings_screen/settings_screen.dart';
 import '../presentation/musali_teaser_screen/musali_teaser_screen.dart';
 import '../presentation/cloud_sync/cloud_sync_screen.dart';
+import '../presentation/mushaf_screen/mushaf_screen.dart';
 
 class AppRoutes {
   static const String onboardingScreen = '/OnboardingScreen';
@@ -31,6 +32,7 @@ class AppRoutes {
   static const String settingsScreen = '/settings';
   static const String musaliTeaserScreen = '/musali_teaser_screen';
   static const String cloudSyncPage = '/cloud_sync';
+  static const String mushafScreen = '/mushaf_screen';
 
   static Map<String, WidgetBuilder> routes = {
     // Changed from get routes =>
@@ -50,5 +52,6 @@ class AppRoutes {
     settingsScreen: (context) => const SettingsScreen(),
     musaliTeaserScreen: (context) => const MusaliTeaserScreen(),
     cloudSyncPage: (context) => const CloudSyncScreen(),
+    mushafScreen: (context) => const MushafScreen(),
   };
 }


### PR DESCRIPTION
Adds a 604-page horizontal RTL mushaf view with:
- PageView with RTL swiping
- Page number indicator with tap-to-jump dialog
- Surah name displayed per page
- Bottom bar showing current page and surah
- Works offline, respects light/dark theme