### PR TITLE
feat: add mushaf type onboarding screen

### DIFF
--- a/lib/core/utils/pref_utils.dart
+++ b/lib/core/utils/pref_utils.dart
@@ -293,4 +293,28 @@ class PrefUtils {
       return 'bidirectional';
     }
   }
+
+  String? getMushafType() {
+    try {
+      return _sharedPreferences?.getString('mushafType');
+    } catch (e) {
+      return null;
+    }
+  }
+
+  Future<void> setMushafType(String type) async {
+    await _sharedPreferences!.setString('mushafType', type);
+  }
+
+  bool getOnboardingCompleted() {
+    try {
+      return _sharedPreferences?.getBool('onboardingCompleted') ?? false;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  Future<void> setOnboardingCompleted(bool value) async {
+    await _sharedPreferences!.setBool('onboardingCompleted', value);
+  }
 }

--- a/lib/localization/ar_eg/ar_eg_translations.dart
+++ b/lib/localization/ar_eg/ar_eg_translations.dart
@@ -254,17 +254,21 @@ final Map<String, String> arEg = {
   'msg_copy_text_desc': 'نسخ نص الآية فقط',
   'msg_text_copied': 'تم نسخ النص',
   'msg_via_app': 'عبر حافظ',
-  
+
   // Audio Player
   'lbl_sleep_timer': 'مؤقت النوم',
   'lbl_cancel_timer': 'إلغاء المؤقت',
   'lbl_minutes': 'دقيقة',
   'lbl_loop_verses': 'تكرار',
   'msg_audio_load_error': 'فشل تحميل الصوت',
-  
+
   // Mushaf Screen
   'lbl_mushaf': 'المصحف',
   'lbl_jump_to_page': 'الانتقال لصفحة',
   'lbl_page': 'صفحة',
   'lbl_go': 'اذهب',
+
+  // Mushaf Type Onboarding
+  'lbl_select_mushaf_type': 'اختر نوع المصحف',
+  'msg_mushaf_type_desc': 'اختر نمط الخط المفضل لديك',
 };

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -257,17 +257,21 @@ final Map<String, String> enUs = {
   'msg_copy_text_desc': 'Copy verse text only',
   'msg_text_copied': 'Text copied to clipboard',
   'msg_via_app': 'via Hafiz',
-  
+
   // Audio Player
   'lbl_sleep_timer': 'Sleep Timer',
   'lbl_cancel_timer': 'Cancel Timer',
   'lbl_minutes': 'minutes',
   'lbl_loop_verses': 'Loop',
   'msg_audio_load_error': 'Failed to load audio',
-  
+
   // Mushaf Screen
   'lbl_mushaf': 'Mushaf',
   'lbl_jump_to_page': 'Jump to Page',
   'lbl_page': 'Page',
   'lbl_go': 'Go',
+
+  // Mushaf Type Onboarding
+  'lbl_select_mushaf_type': 'Choose Mushaf Type',
+  'msg_mushaf_type_desc': 'Select your preferred Quran script style',
 };

--- a/lib/presentation/onboarding_screen/mushaf_type_onboarding.dart
+++ b/lib/presentation/onboarding_screen/mushaf_type_onboarding.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import '../../core/app_export.dart';
+
+enum MushafType {
+  madani('Madani', 'مدني', 'Hafs from Madinah', Colors.teal),
+  egyptian('Egyptian', 'مصري', 'Hafs from Egypt', Colors.blueAccent),
+  indopak('Indo-Pak', 'هندي/باكستاني', 'Nastaleeq script', Colors.orange),
+  warsh('Warsh', 'ورش', 'Warsh from North Africa', Colors.purple);
+
+  const MushafType(this.nameEn, this.nameAr, this.description, this.color);
+  final String nameEn;
+  final String nameAr;
+  final String description;
+  final Color color;
+}
+
+class MushafTypeOnboarding extends StatefulWidget {
+  const MushafTypeOnboarding({super.key});
+
+  @override
+  State<MushafTypeOnboarding> createState() => _MushafTypeOnboardingState();
+}
+
+class _MushafTypeOnboardingState extends State<MushafTypeOnboarding> {
+  MushafType? _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    final saved = PrefUtils().getMushafType();
+    if (saved != null) {
+      _selected = MushafType.values.firstWhere(
+        (t) => t.name == saved,
+        orElse: () => MushafType.madani,
+      );
+    }
+  }
+
+  void _select(MushafType type) {
+    setState(() => _selected = type);
+    PrefUtils().setMushafType(type.name);
+  }
+
+  void _skip() {
+    PrefUtils().setMushafType(MushafType.madani.name);
+    PrefUtils().setOnboardingCompleted(true);
+    NavigatorService.pushNamedAndRemoveUntil(AppRoutes.homeScreen);
+  }
+
+  void _continue() {
+    if (_selected == null) {
+      PrefUtils().setMushafType(MushafType.madani.name);
+    }
+    PrefUtils().setOnboardingCompleted(true);
+    NavigatorService.pushNamedAndRemoveUntil(AppRoutes.homeScreen);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isArabic = Localizations.localeOf(context).languageCode == 'ar';
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            const SizedBox(height: 32),
+            Text(
+              'lbl_select_mushaf_type'.tr,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                'msg_mushaf_type_desc'.tr,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withOpacity(0.6),
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 32),
+            Expanded(
+              child: GridView.builder(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  childAspectRatio: 0.85,
+                  crossAxisSpacing: 12,
+                  mainAxisSpacing: 12,
+                ),
+                itemCount: MushafType.values.length,
+                itemBuilder: (context, index) {
+                  final type = MushafType.values[index];
+                  final isSelected = _selected == type;
+
+                  return GestureDetector(
+                    onTap: () => _select(type),
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 200),
+                      decoration: BoxDecoration(
+                        color: isSelected
+                            ? type.color.withOpacity(0.1)
+                            : theme.cardColor,
+                        borderRadius: BorderRadius.circular(16),
+                        border: Border.all(
+                          color: isSelected ? type.color : theme.dividerColor,
+                          width: isSelected ? 2.5 : 1,
+                        ),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Container(
+                              width: 56,
+                              height: 56,
+                              decoration: BoxDecoration(
+                                color: type.color.withOpacity(0.15),
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: Icon(
+                                Icons.menu_book_rounded,
+                                color: type.color,
+                                size: 28,
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              isArabic ? type.nameAr : type.nameEn,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                color: isSelected ? type.color : null,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              type.description,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurface.withOpacity(
+                                  0.5,
+                                ),
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(24),
+              child: Row(
+                children: [
+                  TextButton(onPressed: _skip, child: Text('lbl_skip'.tr)),
+                  const Spacer(),
+                  FilledButton(
+                    onPressed: _continue,
+                    child: Text('lbl_next'.tr),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -16,6 +16,7 @@ import '../presentation/musali_teaser_screen/musali_teaser_screen.dart';
 import '../presentation/cloud_sync/cloud_sync_screen.dart';
 import '../presentation/audio_player/audio_player_screen.dart';
 import '../presentation/mushaf_screen/mushaf_screen.dart';
+import '../presentation/onboarding_screen/mushaf_type_onboarding.dart';
 
 class AppRoutes {
   static const String onboardingScreen = '/OnboardingScreen';
@@ -35,6 +36,7 @@ class AppRoutes {
   static const String cloudSyncPage = '/cloud_sync';
   static const String audioPlayerScreen = '/audio_player';
   static const String mushafScreen = '/mushaf_screen';
+  static const String mushafTypeOnboarding = '/mushaf_type_onboarding';
 
   static Map<String, WidgetBuilder> routes = {
     // Changed from get routes =>
@@ -65,5 +67,6 @@ class AppRoutes {
       );
     },
     mushafScreen: (context) => const MushafScreen(),
+    mushafTypeOnboarding: (context) => const MushafTypeOnboarding(),
   };
 }


### PR DESCRIPTION
First-run screen to select preferred mushaf type (Madani, Egyptian, Indo-Pak, Warsh). Selection persisted in PrefUtils. Skip option defaults to Madani. EN/AR localizations.