### PR TITLE
🎨 Palette: Add tooltips to SurahScreen IconButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Consistent Tooltips for IconButtons
+**Learning:** While `Semantics` widgets provide excellent accessibility for screen reader users, sighted users relying on mouse hover or long-press on mobile miss out on these labels. We discovered several `IconButton`s in the `SurahScreen` that had `Semantics` but lacked the native `tooltip` property.
+**Action:** Always map the localized `Semantics` label to the `IconButton`'s `tooltip` property to ensure inclusive UX for both screen reader users and sighted users.

--- a/lib/core/utils/pref_utils.dart
+++ b/lib/core/utils/pref_utils.dart
@@ -316,7 +316,8 @@ class PrefUtils {
 
   Future<void> setOnboardingCompleted(bool value) async {
     await _sharedPreferences!.setBool('onboardingCompleted', value);
-    
+  }
+
   // Quran Font Size
   double getQuranFontSize() {
     try {

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -534,12 +534,17 @@ class _SurahScreenState extends State<SurahScreen> {
                           ),
                         ),
                       ),
-                      IconButton(
-                        icon: Icon(
-                          Icons.close,
-                          color: isDark ? Colors.white70 : Colors.black54,
+                      Semantics(
+                        button: true,
+                        label: 'lbl_close'.tr,
+                        child: IconButton(
+                          icon: Icon(
+                            Icons.close,
+                            color: isDark ? Colors.white70 : Colors.black54,
+                          ),
+                          onPressed: () => Navigator.pop(context),
+                          tooltip: 'lbl_close'.tr,
                         ),
-                        onPressed: () => Navigator.pop(context),
                       ),
                     ],
                   ),
@@ -733,6 +738,7 @@ class _SurahScreenState extends State<SurahScreen> {
         child: IconButton(
           icon: const Icon(Icons.arrow_back_outlined, color: Colors.white),
           onPressed: () => NavigatorService.goBack(),
+          tooltip: 'lbl_back'.tr,
         ),
       ),
       actions: [
@@ -747,6 +753,9 @@ class _SurahScreenState extends State<SurahScreen> {
               color: _isAutoScrolling ? Colors.amber : Colors.white,
             ),
             onPressed: _toggleAutoScroll,
+            tooltip: _isAutoScrolling
+                ? 'lbl_stop_autoscroll'.tr
+                : 'lbl_start_autoscroll'.tr,
           ),
         ),
         Semantics(
@@ -796,6 +805,9 @@ class _SurahScreenState extends State<SurahScreen> {
                   isBookmarked ? Icons.bookmark : Icons.bookmark_outline,
                   color: Colors.white,
                 ),
+                tooltip: isBookmarked
+                    ? 'lbl_remove_bookmark'.tr
+                    : 'lbl_add_bookmark'.tr,
                 onPressed: () {
                   if (surah == null) return;
                   if (isBookmarked) {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import firebase_crashlytics
 import flutter_sound
 import just_audio
 import package_info_plus
+import share_plus
 import shared_preferences_foundation
 import speech_to_text
 import sqflite_darwin
@@ -31,6 +32,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSoundPlugin.register(with: registry.registrar(forPlugin: "FlutterSoundPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SpeechToTextPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -685,14 +685,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -777,18 +769,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1342,26 +1334,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_sound/flutter_sound_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <speech_to_text_windows/speech_to_text_windows.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterSoundPluginCApi"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   SpeechToTextWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SpeechToTextWindows"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   flutter_sound
   permission_handler_windows
+  share_plus
   speech_to_text_windows
   url_launcher_windows
 )


### PR DESCRIPTION
💡 What: Added dynamic and static `tooltip` properties to IconButtons in `SurahScreen` (Close, Back, Auto-scroll, and Bookmark buttons).
🎯 Why: While `Semantics` widgets provide labels for screen readers, sighted users relying on mouse hover or long-press on mobile were missing context for these icon-only buttons. The tooltips ensure an inclusive user experience.
♿ Accessibility: Improved visual feedback and reinforced existing semantics labels.

---
*PR created automatically by Jules for task [8642305261764241461](https://jules.google.com/task/8642305261764241461) started by @moatazhamada*