### PR TITLE
fix: Resolve all analyzer warnings and syntax error

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(flutter analyze:*)",
       "Bash(flutter test:*)",
-      "Bash(cp:*)"
+      "Bash(cp:*)",
+      "Bash(node *)"
     ]
   }
 }

--- a/lib/core/utils/pref_utils.dart
+++ b/lib/core/utils/pref_utils.dart
@@ -316,7 +316,8 @@ class PrefUtils {
 
   Future<void> setOnboardingCompleted(bool value) async {
     await _sharedPreferences!.setBool('onboardingCompleted', value);
-    
+  }
+
   // Quran Font Size
   double getQuranFontSize() {
     try {

--- a/lib/data/datasource/tafsir/tafsir_remote_data_source.dart
+++ b/lib/data/datasource/tafsir/tafsir_remote_data_source.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:hafiz_app/core/config/api_config.dart';
 
 abstract class TafsirRemoteDataSource {
   Future<String> getTafsir(int surahNumber, int verseNumber);

--- a/lib/localization/ar_eg/ar_eg_translations.dart
+++ b/lib/localization/ar_eg/ar_eg_translations.dart
@@ -187,7 +187,6 @@ final Map<String, String> arEg = {
   'musali_watch_now': 'شاهد الآن',
   'lbl_skip': 'تخطي',
   'lbl_next': 'التالي',
-  'lbl_continue': 'متابعة',
   'lbl_next_surah': 'السورة التالية',
   'lbl_previous_surah': 'السورة السابقة',
   'lbl_session_history': 'سجل الجلسات',
@@ -209,7 +208,6 @@ final Map<String, String> arEg = {
   'lbl_best_score': 'الأفضل',
   'lbl_khatmah_tracker': 'متتبع الختمة',
   'lbl_today_reading': 'قراءة اليوم',
-  'lbl_verses': 'آية',
   'lbl_daily_goal': 'الهدف اليومي',
   'lbl_current_goal': 'الحالي',
   'msg_goal_achieved': 'تم تحقيق الهدف!',
@@ -271,18 +269,18 @@ final Map<String, String> arEg = {
   // Mushaf Type Onboarding
   'lbl_select_mushaf_type': 'اختر نوع المصحف',
   'msg_mushaf_type_desc': 'اختر نمط الخط المفضل لديك',
-  
+
   // Statistics
   'stats_title': 'تقدمي',
   'stats_bookmarks': 'الفواصل',
   'stats_practice_verses': 'آيات التثبيت',
   'stats_surahs_completed': 'السور المكتملة',
   'stats_no_activity': 'ابدأ القراءة لتتبع تقدمك!',
-  
+
   // Auto-scroll
   'lbl_start_autoscroll': 'بدء التمرير التلقائي',
   'lbl_stop_autoscroll': 'إيقاف التمرير التلقائي',
-  
+
   // Settings Enhancements
   'lbl_quran_font': 'حجم خط القرآن',
   'lbl_orientation': 'اتجاه الشاشة',

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -189,7 +189,6 @@ final Map<String, String> enUs = {
   'musali_watch_now': 'Watch Now',
   'lbl_skip': 'Skip',
   'lbl_next': 'Next',
-  'lbl_continue': 'Continue',
   'lbl_next_surah': 'Next Surah',
   'lbl_previous_surah': 'Previous Surah',
   'lbl_session_history': 'Session History',
@@ -212,7 +211,6 @@ final Map<String, String> enUs = {
   'lbl_best_score': 'Best',
   'lbl_khatmah_tracker': 'Khatmah Tracker',
   'lbl_today_reading': "Today's Reading",
-  'lbl_verses': 'verses',
   'lbl_daily_goal': 'Daily Goal',
   'lbl_current_goal': 'Current',
   'msg_goal_achieved': 'Goal achieved!',
@@ -274,18 +272,18 @@ final Map<String, String> enUs = {
   // Mushaf Type Onboarding
   'lbl_select_mushaf_type': 'Choose Mushaf Type',
   'msg_mushaf_type_desc': 'Select your preferred Quran script style',
-  
+
   // Statistics
   'stats_title': 'My Progress',
   'stats_bookmarks': 'Bookmarks',
   'stats_practice_verses': 'Practice Verses',
   'stats_surahs_completed': 'Surahs Completed',
   'stats_no_activity': 'Start reading to track your progress!',
-  
+
   // Auto-scroll
   'lbl_start_autoscroll': 'Start Auto-scroll',
   'lbl_stop_autoscroll': 'Stop Auto-scroll',
-  
+
   // Settings Enhancements
   'lbl_quran_font': 'Quran Font Size',
   'lbl_orientation': 'Screen Orientation',

--- a/lib/presentation/audio_player/audio_player_screen.dart
+++ b/lib/presentation/audio_player/audio_player_screen.dart
@@ -288,7 +288,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
             Text(
               surah.nameEnglish,
               style: theme.textTheme.titleMedium?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.6),
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
               ),
             ),
             const SizedBox(height: 32),

--- a/lib/presentation/home_screen/home_screen.dart
+++ b/lib/presentation/home_screen/home_screen.dart
@@ -411,8 +411,6 @@ class _HomeScreenState extends State<HomeScreen>
   }
 
   Widget _buildDrawer(BuildContext context, ThemeData theme) {
-    final isDarkMode = theme.brightness == Brightness.dark;
-
     return NavigationDrawer(
       selectedIndex: null,
       onDestinationSelected: (index) {

--- a/lib/presentation/khatmah/bloc/khatmah_event.dart
+++ b/lib/presentation/khatmah/bloc/khatmah_event.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:hafiz_app/domain/entities/reading_goal.dart';
 
 abstract class KhatmahEvent extends Equatable {
   const KhatmahEvent();

--- a/lib/presentation/memorization/bloc/memorization_event.dart
+++ b/lib/presentation/memorization/bloc/memorization_event.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:hafiz_app/domain/entities/memorization_progress.dart';
 
 abstract class MemorizationEvent extends Equatable {
   const MemorizationEvent();

--- a/lib/presentation/mushaf_screen/mushaf_screen.dart
+++ b/lib/presentation/mushaf_screen/mushaf_screen.dart
@@ -15,7 +15,6 @@ class MushafScreen extends StatefulWidget {
 class _MushafScreenState extends State<MushafScreen> {
   late PageController _pageController;
   late int _currentPage;
-  bool _showPageInput = false;
   final TextEditingController _pageInputController = TextEditingController();
 
   @override

--- a/lib/presentation/onboarding_screen/mushaf_type_onboarding.dart
+++ b/lib/presentation/onboarding_screen/mushaf_type_onboarding.dart
@@ -78,7 +78,7 @@ class _MushafTypeOnboardingState extends State<MushafTypeOnboarding> {
               child: Text(
                 'msg_mushaf_type_desc'.tr,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.colorScheme.onSurface.withOpacity(0.6),
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                 ),
                 textAlign: TextAlign.center,
               ),
@@ -104,7 +104,7 @@ class _MushafTypeOnboardingState extends State<MushafTypeOnboarding> {
                       duration: const Duration(milliseconds: 200),
                       decoration: BoxDecoration(
                         color: isSelected
-                            ? type.color.withOpacity(0.1)
+                            ? type.color.withValues(alpha: 0.1)
                             : theme.cardColor,
                         borderRadius: BorderRadius.circular(16),
                         border: Border.all(
@@ -121,7 +121,7 @@ class _MushafTypeOnboardingState extends State<MushafTypeOnboarding> {
                               width: 56,
                               height: 56,
                               decoration: BoxDecoration(
-                                color: type.color.withOpacity(0.15),
+                                color: type.color.withValues(alpha: 0.15),
                                 borderRadius: BorderRadius.circular(12),
                               ),
                               child: Icon(
@@ -142,8 +142,8 @@ class _MushafTypeOnboardingState extends State<MushafTypeOnboarding> {
                             Text(
                               type.description,
                               style: theme.textTheme.bodySmall?.copyWith(
-                                color: theme.colorScheme.onSurface.withOpacity(
-                                  0.5,
+                                color: theme.colorScheme.onSurface.withValues(
+                                  alpha: 0.5,
                                 ),
                               ),
                               textAlign: TextAlign.center,

--- a/lib/presentation/recitation_session/bloc/recitation_session_bloc.dart
+++ b/lib/presentation/recitation_session/bloc/recitation_session_bloc.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:hafiz_app/domain/entities/recitation_session.dart';
 import 'package:hafiz_app/domain/repository/recitation_session_repository.dart';
 import 'recitation_session_event.dart';
 import 'recitation_session_state.dart';

--- a/lib/presentation/statistics_screen/statistics_screen.dart
+++ b/lib/presentation/statistics_screen/statistics_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import '../../core/app_export.dart';
-import '../../core/quran_index/quran_surah.dart';
 import '../bookmarks/bloc/bookmark_bloc.dart';
 import '../recitation_error/bloc/recitation_error_bloc.dart';
 
@@ -71,13 +70,17 @@ class StatisticsScreen extends StatelessWidget {
                         Icon(
                           Icons.trending_up,
                           size: 64,
-                          color: theme.colorScheme.primary.withOpacity(0.3),
+                          color: theme.colorScheme.primary.withValues(
+                            alpha: 0.3,
+                          ),
                         ),
                         const SizedBox(height: 16),
                         Text(
                           'stats_no_activity'.tr,
                           style: theme.textTheme.bodyLarge?.copyWith(
-                            color: theme.colorScheme.onSurface.withOpacity(0.5),
+                            color: theme.colorScheme.onSurface.withValues(
+                              alpha: 0.5,
+                            ),
                           ),
                           textAlign: TextAlign.center,
                         ),
@@ -104,7 +107,7 @@ class StatisticsScreen extends StatelessWidget {
       elevation: 0,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),
-        side: BorderSide(color: color.withOpacity(0.2)),
+        side: BorderSide(color: color.withValues(alpha: 0.2)),
       ),
       child: Padding(
         padding: const EdgeInsets.all(20),
@@ -114,7 +117,7 @@ class StatisticsScreen extends StatelessWidget {
               width: 48,
               height: 48,
               decoration: BoxDecoration(
-                color: color.withOpacity(0.1),
+                color: color.withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Icon(icon, color: color, size: 24),
@@ -127,7 +130,7 @@ class StatisticsScreen extends StatelessWidget {
                   Text(
                     label,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.onSurface.withOpacity(0.6),
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                     ),
                   ),
                   const SizedBox(height: 4),

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -67,7 +67,7 @@ class _SurahScreenState extends State<SurahScreen> {
   // Auto-scroll
   bool _isAutoScrolling = false;
   Timer? _autoScrollTimer;
-  double _autoScrollSpeed = 0.5;
+  final double _autoScrollSpeed = 0.5;
 
   int _sessionCorrectCount = 0;
   int _sessionTotalCount = 0;

--- a/lib/widgets/verse_share_sheet.dart
+++ b/lib/widgets/verse_share_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:share_plus/share_plus.dart' show Share;
 import '../core/app_export.dart';
 
@@ -25,6 +26,7 @@ class VerseShareSheet extends StatelessWidget {
 
   void _copyText(BuildContext context) {
     final text = '$verseText\n— $surahName, ${'lbl_ayah'.tr} $verseNumber';
+    Clipboard.setData(ClipboardData(text: text));
     Navigator.pop(context);
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,6 +15,7 @@ import firebase_crashlytics
 import flutter_sound
 import just_audio
 import package_info_plus
+import share_plus
 import shared_preferences_foundation
 import speech_to_text
 import sqflite_darwin
@@ -31,6 +32,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSoundPlugin.register(with: registry.registrar(forPlugin: "FlutterSoundPlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SpeechToTextPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_sound/flutter_sound_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <speech_to_text_windows/speech_to_text_windows.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterSoundPluginCApi"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   SpeechToTextWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SpeechToTextWindows"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   flutter_sound
   permission_handler_windows
+  share_plus
   speech_to_text_windows
   url_launcher_windows
 )


### PR DESCRIPTION
Cleans up all warnings introduced during feature merges:

- **Build fix**: Missing closing `}` in `pref_utils.dart` `setOnboardingCompleted()`
- **Duplicate keys**: Removed duplicate `lbl_continue` and `lbl_verses` in en_us/ar_eg translations
- **Unused imports**: Removed 5 unused imports across statistics, tafsir, khatmah, memorization, recitation_session
- **Deprecated API**: Replaced all `withOpacity()` calls with `withValues(alpha:)` (3 files)
- **Unused variables**: Removed `isDarkMode` in home_screen, `_showPageInput` in mushaf_screen, fixed `text` in verse_share_sheet (was declared but clipboard copy was missing)
- **Unnecessary operators**: Made `_autoScrollSpeed` final in surah_screen