### PR TITLE
feat: Wire up orphaned screens and activate dead settings

### DIFF
--- a/lib/localization/ar_eg/ar_eg_translations.dart
+++ b/lib/localization/ar_eg/ar_eg_translations.dart
@@ -292,4 +292,5 @@ final Map<String, String> arEg = {
   'lbl_reading_navigation': 'التنقل أثناء القراءة',
   'lbl_scroll_mode': 'وضع التمرير',
   'lbl_page_mode': 'وضع الصفحات',
+  'lbl_audio_player': 'مشغل الصوت',
 };

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -295,4 +295,5 @@ final Map<String, String> enUs = {
   'lbl_reading_navigation': 'Reading Navigation',
   'lbl_scroll_mode': 'Scroll Mode',
   'lbl_page_mode': 'Page Mode',
+  'lbl_audio_player': 'Audio Player',
 };

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -147,7 +147,6 @@ class _BootstrapAppState extends State<BootstrapApp> {
 
   Future<void> _init() async {
     // 1. Critical functional initialization (fast)
-    await SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
     await SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     SystemChrome.setSystemUIOverlayStyle(
       const SystemUiOverlayStyle(
@@ -170,6 +169,28 @@ class _BootstrapAppState extends State<BootstrapApp> {
       await Hive.openBox('reading_goal');
 
       await di.init();
+
+      final orientationMode = PrefUtils().getOrientationMode();
+      List<DeviceOrientation> orientations;
+      switch (orientationMode) {
+        case 'portrait':
+          orientations = [DeviceOrientation.portraitUp];
+          break;
+        case 'landscape':
+          orientations = [
+            DeviceOrientation.landscapeLeft,
+            DeviceOrientation.landscapeRight,
+          ];
+          break;
+        default:
+          orientations = [
+            DeviceOrientation.portraitUp,
+            DeviceOrientation.portraitDown,
+            DeviceOrientation.landscapeLeft,
+            DeviceOrientation.landscapeRight,
+          ];
+      }
+      await SystemChrome.setPreferredOrientations(orientations);
 
       final storage = await HydratedStorage.build(
         storageDirectory: HydratedStorageDirectory(

--- a/lib/presentation/home_screen/home_screen.dart
+++ b/lib/presentation/home_screen/home_screen.dart
@@ -383,10 +383,18 @@ class _HomeScreenState extends State<HomeScreen>
                                   onTap: () {
                                     PrefUtils().saveLastReadSurah(surah);
                                     homeBloc.add(HomeShowLastSurahEvent());
-                                    NavigatorService.pushNamed(
-                                      AppRoutes.surahPage,
-                                      arguments: surah,
-                                    );
+                                    final defaultView = PrefUtils()
+                                        .getDefaultQuranView();
+                                    if (defaultView == 'mushaf') {
+                                      NavigatorService.pushNamed(
+                                        AppRoutes.mushafScreen,
+                                      );
+                                    } else {
+                                      NavigatorService.pushNamed(
+                                        AppRoutes.surahPage,
+                                        arguments: surah,
+                                      );
+                                    }
                                   },
                                   child: SurahListItem(
                                     surahId: surah.id,
@@ -432,9 +440,15 @@ class _HomeScreenState extends State<HomeScreen>
             NavigatorService.pushNamed(AppRoutes.khatmahPage);
             break;
           case 5:
-            NavigatorService.pushNamed(AppRoutes.settingsScreen);
+            NavigatorService.pushNamed(AppRoutes.statisticsScreen);
             break;
           case 6:
+            NavigatorService.pushNamed(AppRoutes.mushafScreen);
+            break;
+          case 7:
+            NavigatorService.pushNamed(AppRoutes.settingsScreen);
+            break;
+          case 8:
             NavigatorService.pushNamed(AppRoutes.aboutPage);
             break;
         }
@@ -492,6 +506,16 @@ class _HomeScreenState extends State<HomeScreen>
           icon: const Icon(Icons.auto_stories_outlined),
           selectedIcon: const Icon(Icons.auto_stories_rounded),
           label: Text('lbl_khatmah_tracker'.tr),
+        ),
+        NavigationDrawerDestination(
+          icon: const Icon(Icons.trending_up_outlined),
+          selectedIcon: const Icon(Icons.trending_up_rounded),
+          label: Text('stats_title'.tr),
+        ),
+        NavigationDrawerDestination(
+          icon: const Icon(Icons.auto_stories_outlined),
+          selectedIcon: const Icon(Icons.auto_stories_rounded),
+          label: Text('lbl_mushaf'.tr),
         ),
         const Divider(height: 24),
         NavigationDrawerDestination(
@@ -657,15 +681,23 @@ class _HomeScreenState extends State<HomeScreen>
                               offset ?? 0.0,
                             );
 
-                            NavigatorService.pushNamed(
-                              AppRoutes.surahPage,
-                              arguments: {
-                                'surah': lastReadSurah,
-                                'offset': ?offset,
-                                'resume': true,
-                                'verseIndex': ?lastVerseIndex,
-                              },
-                            );
+                            final defaultView = PrefUtils()
+                                .getDefaultQuranView();
+                            if (defaultView == 'mushaf') {
+                              NavigatorService.pushNamed(
+                                AppRoutes.mushafScreen,
+                              );
+                            } else {
+                              NavigatorService.pushNamed(
+                                AppRoutes.surahPage,
+                                arguments: {
+                                  'surah': lastReadSurah,
+                                  'offset': ?offset,
+                                  'resume': true,
+                                  'verseIndex': ?lastVerseIndex,
+                                },
+                              );
+                            }
                           },
                           style: ElevatedButton.styleFrom(
                             backgroundColor: Colors.white,

--- a/lib/presentation/onboarding_screen/onboarding_screen.dart
+++ b/lib/presentation/onboarding_screen/onboarding_screen.dart
@@ -214,7 +214,7 @@ class _OnboardingScreenState extends State<OnboardingScreen>
                                   key: const ValueKey('get_started_key'),
                                   onPressed: () {
                                     NavigatorService.pushNamedAndRemoveUntil(
-                                      AppRoutes.musaliTeaserScreen,
+                                      AppRoutes.mushafTypeOnboarding,
                                     );
                                   },
                                   text: 'lbl_get_started'.tr,

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -738,6 +738,27 @@ class _SurahScreenState extends State<SurahScreen> {
       actions: [
         Semantics(
           button: true,
+          label: 'lbl_audio_player'.tr,
+          child: IconButton(
+            icon: const Icon(Icons.headphones, color: Colors.white),
+            onPressed: () {
+              if (surah == null) return;
+              final isArabic =
+                  Localizations.localeOf(context).languageCode == 'ar';
+              NavigatorService.pushNamed(
+                AppRoutes.audioPlayerScreen,
+                arguments: {
+                  'surahId': surah!.id,
+                  'surahName': isArabic
+                      ? surah!.nameArabic
+                      : surah!.nameEnglish,
+                },
+              );
+            },
+          ),
+        ),
+        Semantics(
+          button: true,
           label: _isAutoScrolling
               ? 'lbl_stop_autoscroll'.tr
               : 'lbl_start_autoscroll'.tr,


### PR DESCRIPTION
Connects 4 screens that had code but were unreachable from the UI:

### Screens Connected
- **Statistics** — Added to navigation drawer between Khatmah and Settings
- **Mushaf View** — Added to navigation drawer
- **Audio Player** — Added headphones button to surah screen app bar
- **Mushaf Type Onboarding** — Integrated into onboarding flow (replaces Musali teaser in the chain)

### Dead Settings Activated
- **Default Quran View** — Home screen now respects the surah/mushaf preference for last-read card and surah list taps
- **Orientation Mode** — main.dart now reads the setting instead of hardcoding portraitUp

### Notes
- Reading Navigation Mode setting is still saved but not consumed (requires significant surah screen refactor)
- Musali teaser removed from onboarding flow (deferred per user feedback)