### PR TITLE
fix: Resolve remaining lint warnings

### DIFF
--- a/lib/data/datasource/cloud_sync/cloud_sync_remote_data_source.dart
+++ b/lib/data/datasource/cloud_sync/cloud_sync_remote_data_source.dart
@@ -122,8 +122,9 @@ class CloudSyncRemoteDataSourceImpl implements CloudSyncRemoteDataSource {
       final snapshot = await _bookmarksCollection(userId).get();
       return snapshot.docs.map((doc) {
         final data = doc.data();
-        if (data is! Map<String, dynamic>)
+        if (data is! Map<String, dynamic>) {
           return BookmarkModel.fromJson(const {});
+        }
         return BookmarkModel.fromJson(data);
       }).toList();
     } catch (e) {

--- a/lib/data/datasource/local/local_surah_datasource.dart
+++ b/lib/data/datasource/local/local_surah_datasource.dart
@@ -24,7 +24,7 @@ class LocalSurahDataSource {
   /// Save a Surah to local storage
   Future<void> saveSurah(Surah surah) async {
     final model = SurahModel.fromEntity(surah);
-    surahBox.put('surah_${surah.chapterNumber}', model);
+    await surahBox.put('surah_${surah.chapterNumber}', model);
   }
 
   /// Check if a Surah is downloaded
@@ -45,12 +45,12 @@ class LocalSurahDataSource {
         isDownloaded: isDownloaded,
         lastDownloadedAt: lastDownloadedAt,
       );
-      surahBox.put('surah_$chapterNumber', updatedModel);
+      await surahBox.put('surah_$chapterNumber', updatedModel);
     }
   }
 
   /// Delete a Surah from local storage
   Future<void> deleteSurah(int chapterNumber) async {
-    surahBox.delete('surah_$chapterNumber');
+    await surahBox.delete('surah_$chapterNumber');
   }
 }

--- a/lib/data/datasource/tafsir/tafsir_remote_data_source.dart
+++ b/lib/data/datasource/tafsir/tafsir_remote_data_source.dart
@@ -12,7 +12,7 @@ class TafsirRemoteDataSourceImpl implements TafsirRemoteDataSource {
   @override
   Future<String> getTafsir(int surahNumber, int verseNumber) async {
     final response = await dio.get(
-      '/verses/by_key/${surahNumber}:$verseNumber',
+      '/verses/by_key/$surahNumber:$verseNumber',
       queryParameters: {
         'translations': '169', // Ibn Kathir English (169)
         'fields': 'text_uthmani',

--- a/lib/presentation/khatmah/khatmah_screen.dart
+++ b/lib/presentation/khatmah/khatmah_screen.dart
@@ -3,7 +3,6 @@ import 'package:hafiz_app/core/app_export.dart';
 import 'package:hafiz_app/presentation/khatmah/bloc/khatmah_bloc.dart';
 import 'package:hafiz_app/presentation/khatmah/bloc/khatmah_event.dart';
 import 'package:hafiz_app/presentation/khatmah/bloc/khatmah_state.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hafiz_app/injection_container.dart';
 
 class KhatmahScreen extends StatelessWidget {

--- a/lib/presentation/memorization/memorization_screen.dart
+++ b/lib/presentation/memorization/memorization_screen.dart
@@ -4,7 +4,6 @@ import 'package:hafiz_app/domain/entities/memorization_progress.dart';
 import 'package:hafiz_app/presentation/memorization/bloc/memorization_bloc.dart';
 import 'package:hafiz_app/presentation/memorization/bloc/memorization_event.dart';
 import 'package:hafiz_app/presentation/memorization/bloc/memorization_state.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hafiz_app/injection_container.dart';
 import 'package:hafiz_app/core/quran_index/quran_surah.dart';
 

--- a/lib/presentation/musali_teaser_screen/bloc/musali_teaser_bloc.dart
+++ b/lib/presentation/musali_teaser_screen/bloc/musali_teaser_bloc.dart
@@ -7,7 +7,7 @@ part 'musali_teaser_event.dart';
 part 'musali_teaser_state.dart';
 
 class MusaliTeaserBloc extends Bloc<MusaliTeaserEvent, MusaliTeaserState> {
-  MusaliTeaserBloc() : super(MusaliTeaserInitial()) {
+  MusaliTeaserBloc() : super(const MusaliTeaserInitial()) {
     on<NextSlidePressed>(_onNextSlidePressed);
     on<SkipPressed>(_onSkipPressed);
     on<Dismissed>(_onDismissed);
@@ -26,16 +26,16 @@ class MusaliTeaserBloc extends Bloc<MusaliTeaserEvent, MusaliTeaserState> {
       emit(TeaserSlideUpdated(slideIndex: _currentSlide));
       startAutoSlide();
     } else {
-      emit(TeaserCompleted());
+      emit(const TeaserCompleted());
     }
   }
 
   void _onSkipPressed(SkipPressed event, Emitter<MusaliTeaserState> emit) {
-    emit(TeaserCompleted());
+    emit(const TeaserCompleted());
   }
 
   void _onDismissed(Dismissed event, Emitter<MusaliTeaserState> emit) {
-    emit(TeaserCompleted());
+    emit(const TeaserCompleted());
   }
 
   void _onAutoAdvanceTick(
@@ -52,7 +52,7 @@ class MusaliTeaserBloc extends Bloc<MusaliTeaserEvent, MusaliTeaserState> {
     _autoSlideTimer?.cancel();
     _autoSlideTimer = Timer.periodic(const Duration(seconds: 4), (timer) {
       if (!isClosed) {
-        add(AutoAdvanceTick(shouldAdvance: true));
+        add(const AutoAdvanceTick(shouldAdvance: true));
       }
     });
   }

--- a/lib/presentation/recitation_session/recitation_session_screen.dart
+++ b/lib/presentation/recitation_session/recitation_session_screen.dart
@@ -4,7 +4,6 @@ import 'package:hafiz_app/domain/entities/recitation_session.dart';
 import 'package:hafiz_app/presentation/recitation_session/bloc/recitation_session_bloc.dart';
 import 'package:hafiz_app/presentation/recitation_session/bloc/recitation_session_event.dart';
 import 'package:hafiz_app/presentation/recitation_session/bloc/recitation_session_state.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hafiz_app/injection_container.dart';
 
 class RecitationSessionScreen extends StatelessWidget {

--- a/lib/presentation/surah_screen/bloc/surah_bloc.dart
+++ b/lib/presentation/surah_screen/bloc/surah_bloc.dart
@@ -27,9 +27,11 @@ class SurahBloc extends Bloc<SurahEvent, SurahState> {
       emit(
         response.fold((failure) {
           if (failure is ServerFailure) {
-            return FailureSurahState(errorMessage: 'msg_server_error');
+            return const FailureSurahState(errorMessage: 'msg_server_error');
           } else if (failure is ConnectionFailure) {
-            return FailureSurahState(errorMessage: 'msg_connection_error');
+            return const FailureSurahState(
+              errorMessage: 'msg_connection_error',
+            );
           } else {
             return InitialSurahState();
           }

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -502,98 +502,103 @@ class _SurahScreenState extends State<SurahScreen> {
     if (surah == null) return;
     if (!mounted) return;
 
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (sheetContext) => DraggableScrollableSheet(
-        initialChildSize: 0.5,
-        minChildSize: 0.3,
-        maxChildSize: 0.8,
-        expand: false,
-        builder: (context, scrollController) => FutureBuilder(
-          future: sl<TafsirRepository>().getTafsir(surah!.id, aya.verseNumber),
-          builder: (context, snapshot) {
-            final isDark = PrefUtils().getIsDarkMode() == true;
-            return Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Expanded(
-                        child: Text(
-                          '${'lbl_tafsir'.tr}: ${surah?.localizedName(context)} - ${'lbl_ayah'.tr} ${aya.verseNumber.toLocalizedNumber(context)}',
-                          style: TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                            color: isDark ? Colors.white : Colors.black87,
+    unawaited(
+      showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+        ),
+        builder: (sheetContext) => DraggableScrollableSheet(
+          initialChildSize: 0.5,
+          minChildSize: 0.3,
+          maxChildSize: 0.8,
+          expand: false,
+          builder: (context, scrollController) => FutureBuilder(
+            future: sl<TafsirRepository>().getTafsir(
+              surah!.id,
+              aya.verseNumber,
+            ),
+            builder: (context, snapshot) {
+              final isDark = PrefUtils().getIsDarkMode() == true;
+              return Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(
+                          child: Text(
+                            '${'lbl_tafsir'.tr}: ${surah?.localizedName(context)} - ${'lbl_ayah'.tr} ${aya.verseNumber.toLocalizedNumber(context)}',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                              color: isDark ? Colors.white : Colors.black87,
+                            ),
                           ),
                         ),
-                      ),
-                      IconButton(
-                        icon: Icon(
-                          Icons.close,
-                          color: isDark ? Colors.white70 : Colors.black54,
+                        IconButton(
+                          icon: Icon(
+                            Icons.close,
+                            color: isDark ? Colors.white70 : Colors.black54,
+                          ),
+                          onPressed: () => Navigator.pop(context),
                         ),
-                        onPressed: () => Navigator.pop(context),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-                const Divider(height: 1),
-                Expanded(
-                  child: snapshot.connectionState == ConnectionState.waiting
-                      ? const Center(child: CircularProgressIndicator())
-                      : snapshot.hasError || snapshot.data?.isLeft() == true
-                      ? Center(
-                          child: Padding(
-                            padding: const EdgeInsets.all(32),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Icon(
-                                  Icons.error_outline,
-                                  size: 48,
-                                  color: Colors.grey[400],
-                                ),
-                                const SizedBox(height: 16),
-                                Text(
-                                  'msg_tafsir_error'.tr,
-                                  textAlign: TextAlign.center,
-                                  style: TextStyle(color: Colors.grey[600]),
-                                ),
-                              ],
+                  const Divider(height: 1),
+                  Expanded(
+                    child: snapshot.connectionState == ConnectionState.waiting
+                        ? const Center(child: CircularProgressIndicator())
+                        : snapshot.hasError || snapshot.data?.isLeft() == true
+                        ? Center(
+                            child: Padding(
+                              padding: const EdgeInsets.all(32),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(
+                                    Icons.error_outline,
+                                    size: 48,
+                                    color: Colors.grey[400],
+                                  ),
+                                  const SizedBox(height: 16),
+                                  Text(
+                                    'msg_tafsir_error'.tr,
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(color: Colors.grey[600]),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
-                        )
-                      : SingleChildScrollView(
-                          controller: scrollController,
-                          padding: const EdgeInsets.all(16),
-                          child: snapshot.data!.fold(
-                            (failure) => Text(
-                              'msg_tafsir_error'.tr,
-                              style: TextStyle(color: Colors.grey[600]),
-                            ),
-                            (tafsir) => Text(
-                              _stripHtmlTags(tafsir.text),
-                              style: TextStyle(
-                                fontSize: 16,
-                                height: 1.8,
-                                color: isDark
-                                    ? Colors.grey[300]
-                                    : Colors.black87,
+                          )
+                        : SingleChildScrollView(
+                            controller: scrollController,
+                            padding: const EdgeInsets.all(16),
+                            child: snapshot.data!.fold(
+                              (failure) => Text(
+                                'msg_tafsir_error'.tr,
+                                style: TextStyle(color: Colors.grey[600]),
+                              ),
+                              (tafsir) => Text(
+                                _stripHtmlTags(tafsir.text),
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  height: 1.8,
+                                  color: isDark
+                                      ? Colors.grey[300]
+                                      : Colors.black87,
+                                ),
                               ),
                             ),
                           ),
-                        ),
-                ),
-              ],
-            );
-          },
+                  ),
+                ],
+              );
+            },
+          ),
         ),
       ),
     );

--- a/test/core/utils/navigator_service_test.dart
+++ b/test/core/utils/navigator_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hafiz_app/core/utils/navigator_service.dart';
@@ -20,7 +22,7 @@ void main() {
         ),
       );
 
-      NavigatorService.pushNamed('/test');
+      unawaited(NavigatorService.pushNamed('/test'));
       await tester.pumpAndSettle();
 
       expect(find.text('Test Route'), findsOneWidget);
@@ -38,7 +40,7 @@ void main() {
         ),
       );
 
-      NavigatorService.pushNamed('/second');
+      unawaited(NavigatorService.pushNamed('/second'));
       await tester.pumpAndSettle();
       expect(find.text('Second'), findsOneWidget);
 


### PR DESCRIPTION
Cleans up the remaining 22 Dart lint issues visible in VS Code:

- **unawaited_futures**: Wrap fire-and-forget futures with `unawaited()` in surah_screen (tafsir sheet) and navigator_service_test
- **unawaited_futures**: Add missing `await` on Hive Box operations in local_surah_datasource  
- **unnecessary_import**: Remove redundant `flutter_bloc` imports (already in `app_export.dart`) from 3 screens
- **prefer_const_constructors**: Add `const` to state/event constructors in musali_teaser_bloc and surah_bloc
- **curly_braces_in_flow_control_structures**: Add braces to if-statement in cloud_sync_remote_data_source
- **unnecessary_brace_in_string_interps**: Remove unnecessary braces in tafsir URL

Note: The 4 `unnecessary_non_null_assertion` warnings in surah_screen.dart (lines 428/433/455/460) are kept — the `!` operators are required for compilation since Dart cannot promote `Surah?` types through indirect boolean guards.