### PR TITLE
fix: RTL text direction for all Quran content and navigation arrows

### DIFF
--- a/lib/presentation/audio_player/audio_player_screen.dart
+++ b/lib/presentation/audio_player/audio_player_screen.dart
@@ -267,6 +267,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
       appBar: AppBar(
         title: Text(
           surah.nameArabic,
+          textDirection: TextDirection.rtl,
           style: const TextStyle(fontFamily: 'Amiri'),
         ),
         centerTitle: true,
@@ -278,6 +279,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
             const Spacer(flex: 2),
             Text(
               surah.nameArabic,
+              textDirection: TextDirection.rtl,
               style: const TextStyle(
                 fontFamily: 'Amiri',
                 fontSize: 36,

--- a/lib/presentation/bookmarks/bookmarks_screen.dart
+++ b/lib/presentation/bookmarks/bookmarks_screen.dart
@@ -188,6 +188,7 @@ class BookmarksScreen extends StatelessWidget {
                                     children: [
                                       Text(
                                         surah.localizedName(context),
+                                        textDirection: TextDirection.rtl,
                                         style: TextStyle(
                                           fontFamily: 'Poppins',
                                           fontWeight: FontWeight.w600,

--- a/lib/presentation/home_screen/home_screen.dart
+++ b/lib/presentation/home_screen/home_screen.dart
@@ -628,6 +628,7 @@ class _HomeScreenState extends State<HomeScreen>
                                 ),
                               Text(
                                 lastReadSurah.nameArabic,
+                                textDirection: TextDirection.rtl,
                                 style: theme.textTheme.headlineMedium?.copyWith(
                                   fontFamily: 'Amiri',
                                   color: Colors.white.withValues(alpha: 0.9),

--- a/lib/presentation/mushaf_screen/mushaf_screen.dart
+++ b/lib/presentation/mushaf_screen/mushaf_screen.dart
@@ -159,6 +159,7 @@ class _MushafScreenState extends State<MushafScreen> {
                 children: [
                   Text(
                     surah.nameArabic,
+                    textDirection: TextDirection.rtl,
                     style: TextStyle(
                       fontFamily: 'Amiri',
                       fontSize: 28,
@@ -169,6 +170,7 @@ class _MushafScreenState extends State<MushafScreen> {
                   const SizedBox(height: 8),
                   Text(
                     isArabic ? surah.nameArabic : surah.nameEnglish,
+                    textDirection: TextDirection.rtl,
                     style: TextStyle(
                       fontSize: 16,
                       color: isDark ? Colors.white54 : Colors.black54,
@@ -226,6 +228,7 @@ class _MushafScreenState extends State<MushafScreen> {
           children: [
             Text(
               isArabic ? surah.nameArabic : surah.nameEnglish,
+              textDirection: TextDirection.rtl,
               style: theme.textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.w500,
               ),

--- a/lib/presentation/recitation_error/recitation_error_screen.dart
+++ b/lib/presentation/recitation_error/recitation_error_screen.dart
@@ -163,6 +163,7 @@ class RecitationErrorScreen extends StatelessWidget {
                                                 QuranIndex.quranSurahs[0],
                                           )
                                           .localizedName(context),
+                                      textDirection: TextDirection.rtl,
                                       style: TextStyle(
                                         fontFamily: 'Poppins',
                                         fontWeight: FontWeight.w600,

--- a/lib/presentation/settings_screen/settings_screen.dart
+++ b/lib/presentation/settings_screen/settings_screen.dart
@@ -136,6 +136,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               children: [
                 Text(
                   'بِسْمِ اللَّهِ',
+                  textDirection: TextDirection.rtl,
                   style: TextStyle(
                     fontFamily: 'Amiri',
                     fontSize: _quranFontSize,

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -470,9 +470,10 @@ class _SurahScreenState extends State<SurahScreen> {
                       '${'lbl_previous_surah'.tr}: ${isArabic ? prevSurah!.nameArabic : prevSurah!.nameEnglish}',
                   child: TextButton.icon(
                     onPressed: () => _navigateToSurah(surah!.id - 1),
-                    icon: const Icon(Icons.skip_previous, size: 18),
+                    icon: const Icon(Icons.skip_next, size: 18),
                     label: Text(
                       isArabic ? prevSurah!.nameArabic : prevSurah!.nameEnglish,
+                      textDirection: TextDirection.rtl,
                       style: const TextStyle(fontSize: 13),
                       overflow: TextOverflow.ellipsis,
                       maxLines: 1,
@@ -497,9 +498,10 @@ class _SurahScreenState extends State<SurahScreen> {
                       '${'lbl_next_surah'.tr}: ${isArabic ? nextSurah!.nameArabic : nextSurah!.nameEnglish}',
                   child: TextButton.icon(
                     onPressed: () => _navigateToSurah(surah!.id + 1),
-                    icon: const Icon(Icons.skip_next, size: 18),
+                    icon: const Icon(Icons.skip_previous, size: 18),
                     label: Text(
                       isArabic ? nextSurah!.nameArabic : nextSurah!.nameEnglish,
+                      textDirection: TextDirection.rtl,
                       style: const TextStyle(fontSize: 13),
                       overflow: TextOverflow.ellipsis,
                       maxLines: 1,
@@ -626,6 +628,7 @@ class _SurahScreenState extends State<SurahScreen> {
                               ),
                               (tafsir) => Text(
                                 _stripHtmlTags(tafsir.text),
+                                textDirection: TextDirection.rtl,
                                 style: TextStyle(
                                   fontSize: 16,
                                   height: 1.8,
@@ -934,6 +937,7 @@ class _SurahScreenState extends State<SurahScreen> {
             header: true,
             child: Text(
               surah?.localizedName(context) ?? '',
+              textDirection: TextDirection.rtl,
               style: const TextStyle(
                 fontSize: 20,
                 fontWeight: FontWeight.w700,

--- a/lib/presentation/surah_screen/widgets/voice_verification_dialog.dart
+++ b/lib/presentation/surah_screen/widgets/voice_verification_dialog.dart
@@ -479,6 +479,7 @@ class _VoiceVerificationDialogState extends State<VoiceVerificationDialog> {
               child: Text(
                 _spokenText,
                 textAlign: TextAlign.center,
+                textDirection: TextDirection.rtl,
                 style: TextStyle(
                   fontSize: 18,
                   fontFamily: 'Amiri',
@@ -505,36 +506,39 @@ class _VoiceVerificationDialogState extends State<VoiceVerificationDialog> {
                 style: const TextStyle(fontSize: 12, color: Colors.grey),
               ),
             const SizedBox(height: 8),
-            Wrap(
-              spacing: 6,
-              runSpacing: 6,
-              children: _expectedText
-                  .split(RegExp(r'\s+'))
-                  .where((t) => t.isNotEmpty)
-                  .toList()
-                  .asMap()
-                  .entries
-                  .map((entry) {
-                    final idx = entry.key + 1;
-                    final word = entry.value;
-                    final isCorrect = _qrcWordIndex >= idx;
-                    final isMistake = _qrcMistakeIndices.contains(idx);
-                    Color color = Colors.black87;
-                    if (isCorrect) color = Colors.green;
-                    if (isMistake) color = Colors.redAccent;
-                    return Text(
-                      word,
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontFamily: 'Amiri',
-                        color: color,
-                        fontWeight: isCorrect
-                            ? FontWeight.bold
-                            : FontWeight.normal,
-                      ),
-                    );
-                  })
-                  .toList(),
+            Directionality(
+              textDirection: TextDirection.rtl,
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 6,
+                children: _expectedText
+                    .split(RegExp(r'\s+'))
+                    .where((t) => t.isNotEmpty)
+                    .toList()
+                    .asMap()
+                    .entries
+                    .map((entry) {
+                      final idx = entry.key + 1;
+                      final word = entry.value;
+                      final isCorrect = _qrcWordIndex >= idx;
+                      final isMistake = _qrcMistakeIndices.contains(idx);
+                      Color color = Colors.black87;
+                      if (isCorrect) color = Colors.green;
+                      if (isMistake) color = Colors.redAccent;
+                      return Text(
+                        word,
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontFamily: 'Amiri',
+                          color: color,
+                          fontWeight: isCorrect
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                        ),
+                      );
+                    })
+                    .toList(),
+              ),
             ),
             if (_qrcMistakeLines.isNotEmpty) ...[
               const SizedBox(height: 8),
@@ -577,6 +581,7 @@ class _VoiceVerificationDialogState extends State<VoiceVerificationDialog> {
               ),
               Text(
                 _hintWord,
+                textDirection: TextDirection.rtl,
                 style: const TextStyle(fontSize: 14, fontFamily: 'Amiri'),
               ),
             ],
@@ -588,6 +593,7 @@ class _VoiceVerificationDialogState extends State<VoiceVerificationDialog> {
               ),
               Text(
                 _repeatWord,
+                textDirection: TextDirection.rtl,
                 style: const TextStyle(
                   fontSize: 16,
                   fontFamily: 'Amiri',
@@ -611,6 +617,7 @@ class _VoiceVerificationDialogState extends State<VoiceVerificationDialog> {
           Text(
             _expectedText,
             textAlign: TextAlign.center,
+            textDirection: TextDirection.rtl,
             style: const TextStyle(fontSize: 18, fontFamily: 'Amiri'),
           ),
         ],


### PR DESCRIPTION
The Quran is always read RTL regardless of the app's language setting.

### RTL Text Direction
Added `textDirection: TextDirection.rtl` to all Arabic/Quran text rendering across 8 files:
- Surah names in app bar, navigation, mushaf, audio player, home card
- Tafsir text in bottom sheet
- Bismillah font preview in settings
- Voice verification dialog (spoken text, expected text, hint/repeat words, QRC word wrap)
- Bookmark and recitation error screen surah names

### Navigation Arrow Fix
In the surah screen's prev/next navigation bar:
- **Next surah** now uses `Icons.skip_previous` ◁ (pointing left = forward in RTL reading)
- **Previous surah** now uses `Icons.skip_next` ▷ (pointing right = backward in RTL reading)
- This matches the physical Mushaf experience where you flip left to advance