### PR TITLE
⚡ Bolt: Replace shrinkWrap ListView with SliverList for lazy loading in HomeScreen

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+# Bolt's Journal
+## $(date +%Y-%m-%d) - [Replace shrinkWrap ListView inside SingleChildScrollView]
+**Learning:** Using `ListView.builder` with `shrinkWrap: true` inside a `SingleChildScrollView` defeats the purpose of the lazy-loading `.builder` constructor. It forces Flutter to instantiate, layout, and render all children synchronously at once to measure the total height of the `ListView`, causing a huge performance bottleneck (O(N) layout time) and high memory usage.
+**Action:** Always use `CustomScrollView` with `SliverList.builder` instead of `SingleChildScrollView` containing a `shrinkWrap` `ListView` for rendering large lists alongside other content.

--- a/lib/presentation/home_screen/home_screen.dart
+++ b/lib/presentation/home_screen/home_screen.dart
@@ -302,15 +302,14 @@ class _HomeScreenState extends State<HomeScreen>
             builder: (context, state) {
               return SizedBox(
                 width: double.maxFinite,
-                child: SingleChildScrollView(
+                child: CustomScrollView(
                   controller: _scrollController,
                   key: const PageStorageKey('home-scroll'),
-                  padding: const EdgeInsets.only(bottom: 20),
-                  child: Column(
-                    children: [
-                      // Offline indicator banner
-                      if (_isOffline)
-                        Semantics(
+                  slivers: [
+                    // Offline indicator banner
+                    if (_isOffline)
+                      SliverToBoxAdapter(
+                        child: Semantics(
                           liveRegion: true,
                           child: Container(
                             width: double.infinity,
@@ -339,76 +338,76 @@ class _HomeScreenState extends State<HomeScreen>
                             ),
                           ),
                         ),
+                      ),
 
-                      if (state is UpdateLastReadSurah && state.surah != null)
-                        _buildCardLastRead(state.surah, theme),
+                    if (state is UpdateLastReadSurah && state.surah != null)
+                      SliverToBoxAdapter(
+                        child: _buildCardLastRead(state.surah, theme),
+                      ),
 
-                      Semantics(
-                        label: 'lbl_surah_list'.tr,
-                        child: ListView.builder(
-                          key: const PageStorageKey('home-list'),
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemCount: QuranIndex.quranSurahs.length,
-                          itemBuilder: (context, index) {
-                            final surah = QuranIndex.quranSurahs[index];
+                    SliverPadding(
+                      padding: const EdgeInsets.only(bottom: 20),
+                      sliver: SliverList.builder(
+                        key: const PageStorageKey('home-list'),
+                        itemCount: QuranIndex.quranSurahs.length,
+                        itemBuilder: (context, index) {
+                          final surah = QuranIndex.quranSurahs[index];
 
-                            // Simple staggered animation logic
-                            return TweenAnimationBuilder<double>(
-                              tween: Tween(begin: 0.0, end: 1.0),
-                              duration: const Duration(milliseconds: 500),
-                              curve: Curves.easeOutQuad,
-                              // Delay based on index, capped to prevent long waits for bottom items
-                              builder: (context, value, child) {
-                                // Only animate the first 10 items to save performance/time
-                                final shouldAnimate = index < 10;
-                                final opacity = shouldAnimate ? value : 1.0;
-                                final offset = shouldAnimate
-                                    ? Offset(0, 50 * (1 - value))
-                                    : Offset.zero;
+                          // Simple staggered animation logic
+                          return TweenAnimationBuilder<double>(
+                            tween: Tween(begin: 0.0, end: 1.0),
+                            duration: const Duration(milliseconds: 500),
+                            curve: Curves.easeOutQuad,
+                            // Delay based on index, capped to prevent long waits for bottom items
+                            builder: (context, value, child) {
+                              // Only animate the first 10 items to save performance/time
+                              final shouldAnimate = index < 10;
+                              final opacity = shouldAnimate ? value : 1.0;
+                              final offset = shouldAnimate
+                                  ? Offset(0, 50 * (1 - value))
+                                  : Offset.zero;
 
-                                return Opacity(
-                                  opacity: opacity,
-                                  child: Transform.translate(
-                                    offset: offset,
-                                    child: child,
-                                  ),
-                                );
-                              },
-                              child: Semantics(
-                                button: true,
-                                label:
-                                    '${surah.nameEnglish}, ${surah.nameArabic}, ${'lbl_surah'.tr} ${surah.id}',
-                                child: InkWell(
-                                  onTap: () {
-                                    PrefUtils().saveLastReadSurah(surah);
-                                    homeBloc.add(HomeShowLastSurahEvent());
-                                    final defaultView = PrefUtils()
-                                        .getDefaultQuranView();
-                                    if (defaultView == 'mushaf') {
-                                      NavigatorService.pushNamed(
-                                        AppRoutes.mushafScreen,
-                                      );
-                                    } else {
-                                      NavigatorService.pushNamed(
-                                        AppRoutes.surahPage,
-                                        arguments: surah,
-                                      );
-                                    }
-                                  },
-                                  child: SurahListItem(
-                                    surahId: surah.id,
-                                    nameEnglish: surah.nameEnglish,
-                                    nameArabic: surah.nameArabic,
-                                  ),
+                              return Opacity(
+                                opacity: opacity,
+                                child: Transform.translate(
+                                  offset: offset,
+                                  child: child,
+                                ),
+                              );
+                            },
+                            child: Semantics(
+                              button: true,
+                              label:
+                                  '${surah.nameEnglish}, ${surah.nameArabic}, ${'lbl_surah'.tr} ${surah.id}',
+                              child: InkWell(
+                                onTap: () {
+                                  PrefUtils().saveLastReadSurah(surah);
+                                  homeBloc.add(HomeShowLastSurahEvent());
+                                  final defaultView = PrefUtils()
+                                      .getDefaultQuranView();
+                                  if (defaultView == 'mushaf') {
+                                    NavigatorService.pushNamed(
+                                      AppRoutes.mushafScreen,
+                                    );
+                                  } else {
+                                    NavigatorService.pushNamed(
+                                      AppRoutes.surahPage,
+                                      arguments: surah,
+                                    );
+                                  }
+                                },
+                                child: SurahListItem(
+                                  surahId: surah.id,
+                                  nameEnglish: surah.nameEnglish,
+                                  nameArabic: surah.nameArabic,
                                 ),
                               ),
-                            );
-                          },
-                        ),
+                            ),
+                          );
+                        },
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               );
             },


### PR DESCRIPTION
💡 **What:** Replaced the `SingleChildScrollView` containing a `ListView.builder(shrinkWrap: true)` with a `CustomScrollView` and `SliverList.builder`. Also reverted accidental pubspec.lock changes from previous test runs and cleaned up scratch pad files.

🎯 **Why:** Using `shrinkWrap: true` on a `ListView.builder` inside a scrollable view forces the list view to calculate the layout size of every single child item (all 114 Surahs) upfront, completely defeating the purpose of the lazy-loading `.builder` constructor. This leads to an O(N) layout time and unnecessarily high memory usage during the first render.

📊 **Impact:** Reduces the initial layout and render time of the `HomeScreen`. Memory usage is decreased as `InkWell` and `TweenAnimationBuilder` instances are only created for the Surahs currently visible on the screen.

🔬 **Measurement:** Verify by launching the app to the HomeScreen and noting the improved initial render time and smoother scroll performance on low-end devices. You can use the Flutter DevTools Performance tab to see the reduced widget rebuild counts and layout times.

---
*PR created automatically by Jules for task [12108621915117483799](https://jules.google.com/task/12108621915117483799) started by @moatazhamada*