### PR TITLE
🎨 Palette: Add semantics and tooltips to media controls

### DIFF
--- a/lib/localization/ar_eg/ar_eg_translations.dart
+++ b/lib/localization/ar_eg/ar_eg_translations.dart
@@ -282,4 +282,6 @@ final Map<String, String> arEg = {
   'lbl_slow': 'بطيء',
   'lbl_normal': 'عادي',
   'lbl_fast': 'سريع',
+  'lbl_rewind_10s': 'إرجاع 10 ثوان',
+  'lbl_forward_10s': 'تقديم 10 ثوان',
 };

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -285,4 +285,6 @@ final Map<String, String> enUs = {
   'lbl_slow': 'Slow',
   'lbl_normal': 'Normal',
   'lbl_fast': 'Fast',
+  'lbl_rewind_10s': 'Rewind 10s',
+  'lbl_forward_10s': 'Forward 10s',
 };

--- a/lib/presentation/audio_player/audio_player_screen.dart
+++ b/lib/presentation/audio_player/audio_player_screen.dart
@@ -379,12 +379,17 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        IconButton(
-          icon: const Icon(Icons.replay_10, size: 32),
-          onPressed: () {
-            _handler.seekRelative(const Duration(seconds: -10));
-            setState(() {});
-          },
+        Semantics(
+          button: true,
+          label: 'lbl_rewind_10s'.tr,
+          child: IconButton(
+            icon: const Icon(Icons.replay_10, size: 32),
+            tooltip: 'lbl_rewind_10s'.tr,
+            onPressed: () {
+              _handler.seekRelative(const Duration(seconds: -10));
+              setState(() {});
+            },
+          ),
         ),
         const SizedBox(width: 24),
         Container(
@@ -402,31 +407,41 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
                     strokeWidth: 2,
                   ),
                 )
-              : IconButton(
-                  icon: Icon(
-                    _handler.isPlaying ? Icons.pause : Icons.play_arrow,
-                    color: Colors.white,
-                    size: 36,
+              : Semantics(
+                  button: true,
+                  label: _handler.isPlaying ? 'lbl_pause'.tr : 'lbl_play'.tr,
+                  child: IconButton(
+                    icon: Icon(
+                      _handler.isPlaying ? Icons.pause : Icons.play_arrow,
+                      color: Colors.white,
+                      size: 36,
+                    ),
+                    tooltip: _handler.isPlaying ? 'lbl_pause'.tr : 'lbl_play'.tr,
+                    onPressed: () {
+                      if (_handler.isPlaying) {
+                        _handler.pause();
+                      } else if (_handler.currentSurahId == widget.surahId) {
+                        _handler.resume();
+                      } else {
+                        _play();
+                      }
+                      setState(() {});
+                    },
                   ),
-                  onPressed: () {
-                    if (_handler.isPlaying) {
-                      _handler.pause();
-                    } else if (_handler.currentSurahId == widget.surahId) {
-                      _handler.resume();
-                    } else {
-                      _play();
-                    }
-                    setState(() {});
-                  },
                 ),
         ),
         const SizedBox(width: 24),
-        IconButton(
-          icon: const Icon(Icons.forward_10, size: 32),
-          onPressed: () {
-            _handler.seekRelative(const Duration(seconds: 10));
-            setState(() {});
-          },
+        Semantics(
+          button: true,
+          label: 'lbl_forward_10s'.tr,
+          child: IconButton(
+            icon: const Icon(Icons.forward_10, size: 32),
+            tooltip: 'lbl_forward_10s'.tr,
+            onPressed: () {
+              _handler.seekRelative(const Duration(seconds: 10));
+              setState(() {});
+            },
+          ),
         ),
       ],
     );


### PR DESCRIPTION
💡 What: Added tooltips and `Semantics` wrappers to the rewind, play/pause, and fast-forward icon-only buttons in the `AudioPlayerScreen`. Created translation keys for rewind and fast-forward in both English and Arabic files.
🎯 Why: Without tooltips or semantics, screen reader users and those relying on long-press/hover would not know what these icon-only buttons do.
📸 Before/After: Before, buttons just showed icons. Now they provide localized descriptions and have tooltips.
♿ Accessibility: Considerably improves usability for screen readers and visually impaired users by adding descriptive labels to the media control buttons.

---
*PR created automatically by Jules for task [5708037297030040015](https://jules.google.com/task/5708037297030040015) started by @moatazhamada*