### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons in Bookmarks Screen

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility: IconButton Tooltips
+**Learning:** `IconButton` widgets should always have a `tooltip` property matching the `Semantics` label. This ensures that while screen readers announce the semantic label, sighted users can discover the functionality through hover or long-press interactions, leading to a universally inclusive experience.
+**Action:** Always map localized `Semantics` labels to the corresponding `tooltip` property on `IconButton` widgets.

--- a/lib/presentation/bookmarks/bookmarks_screen.dart
+++ b/lib/presentation/bookmarks/bookmarks_screen.dart
@@ -19,6 +19,7 @@ class BookmarksScreen extends StatelessWidget {
           button: true,
           label: 'lbl_back'.tr,
           child: IconButton(
+            tooltip: 'lbl_back'.tr,
             icon: const Icon(Icons.arrow_back),
             onPressed: () => NavigatorService.goBack(),
           ),
@@ -211,6 +212,7 @@ class BookmarksScreen extends StatelessWidget {
                                   button: true,
                                   label: 'lbl_delete'.tr,
                                   child: IconButton(
+                                    tooltip: 'lbl_delete'.tr,
                                     icon: const Icon(
                                       Icons.delete_outline,
                                       color: Colors.redAccent,


### PR DESCRIPTION
💡 **What:** Added `tooltip` properties to the 'back' and 'delete' `IconButton`s in `BookmarksScreen`, using existing localized `.tr` strings from their `Semantics` labels. Created `.jules/palette.md` to document this accessibility pattern.

🎯 **Why:** While screen readers correctly announce the semantic label, sighted users might rely on tooltips (via hover on desktop or long-press on mobile) to discover the functionality of icon-only buttons. This ensures a universally inclusive experience.

♿ **Accessibility:** Enhances discoverability of icon-only button functionalities for users employing diverse interaction methods.

---
*PR created automatically by Jules for task [16702900506194111051](https://jules.google.com/task/16702900506194111051) started by @moatazhamada*