### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Always pair Semantics with tooltips on IconButtons
+**Learning:** Adding `Semantics(label: ...)` to an `IconButton` correctly exposes the action to screen readers, but it leaves sighted users (especially on desktop/web, or those using mice) without visual feedback on what the icon-only button does. We discovered a pattern in this app where `Semantics` was used exclusively, omitting the native `tooltip` property.
+**Action:** Always map localized `Semantics` labels to the corresponding `tooltip` property on `IconButton` widgets. This ensures an inclusive user experience for both screen reader users and sighted users relying on hover or long-press interactions.

--- a/lib/presentation/bookmarks/bookmarks_screen.dart
+++ b/lib/presentation/bookmarks/bookmarks_screen.dart
@@ -21,6 +21,7 @@ class BookmarksScreen extends StatelessWidget {
           child: IconButton(
             icon: const Icon(Icons.arrow_back),
             onPressed: () => NavigatorService.goBack(),
+            tooltip: 'lbl_back'.tr,
           ),
         ),
         centerTitle: true,
@@ -223,6 +224,7 @@ class BookmarksScreen extends StatelessWidget {
                                         ),
                                       );
                                     },
+                                    tooltip: 'lbl_delete'.tr,
                                   ),
                                 ),
                               ],

--- a/lib/presentation/search/search_screen.dart
+++ b/lib/presentation/search/search_screen.dart
@@ -38,6 +38,7 @@ class _SearchScreenState extends State<SearchScreen> {
             child: IconButton(
               icon: const Icon(Icons.arrow_back, color: Colors.white),
               onPressed: () => NavigatorService.goBack(),
+              tooltip: 'lbl_back'.tr,
             ),
           ),
           title: Semantics(

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -588,6 +588,7 @@ class _SurahScreenState extends State<SurahScreen> {
                             color: isDark ? Colors.white70 : Colors.black54,
                           ),
                           onPressed: () => Navigator.pop(context),
+                          tooltip: 'lbl_close'.tr,
                         ),
                       ],
                     ),
@@ -782,6 +783,7 @@ class _SurahScreenState extends State<SurahScreen> {
         child: IconButton(
           icon: const Icon(Icons.arrow_back_outlined, color: Colors.white),
           onPressed: () => NavigatorService.goBack(),
+          tooltip: 'lbl_back'.tr,
         ),
       ),
       actions: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -685,14 +685,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -777,18 +769,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1342,26 +1334,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
💡 **What:** Added `tooltip` properties to multiple icon-only `IconButton`s in `BookmarksScreen`, `SearchScreen`, and `SurahScreen`.
🎯 **Why:** To improve discoverability and accessibility. Previously, some buttons used `Semantics` wrappers but lacked native tooltips, leaving sighted users (especially on desktop or using a mouse) without a way to identify the button's action on hover.
♿ **Accessibility:** Utilizing the native `tooltip` property on `IconButton` automatically provides the correct semantic label to screen readers while also showing a visual tooltip to sighted users.

---
*PR created automatically by Jules for task [7165073897514383616](https://jules.google.com/task/7165073897514383616) started by @moatazhamada*