### PR TITLE
⚡ Bolt: Add virtualization to long list rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - [Optimize Single-Line View performance]
+**Learning:** `ListView` mapped over `children: chapters.map` is inefficient for lists inside a `CustomScrollView`. Using `SliverList.builder` inside `SliverMainAxisGroup` is much better for lazy loading elements inside the scroll view.
+**Action:** Used `SliverList.builder` for the single line verse view to preserve list virtualization and avoid large O(N) operations.

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -1392,32 +1392,51 @@ class _SurahScreenState extends State<SurahScreen> {
     RecitationErrorState errorState,
     bool isDark,
   ) {
-    return SliverToBoxAdapter(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _buildBismillah(isDark),
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: PrefUtils().getVerseViewMode()
-                ? _buildSingleLineContent(
-                    context,
-                    chapters,
-                    bookmarkState,
-                    errorState,
-                    isDark,
-                  )
-                : _buildRichTextContent(
-                    context,
-                    chapters,
-                    bookmarkState,
-                    errorState,
-                    isDark,
-                  ),
+    if (PrefUtils().getVerseViewMode()) {
+      return SliverMainAxisGroup(
+        slivers: [
+          SliverToBoxAdapter(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _buildBismillah(isDark),
+                const SizedBox(height: 16.0),
+              ],
+            ),
           ),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            sliver: _buildSingleLineContentSliver(
+              context,
+              chapters,
+              bookmarkState,
+              errorState,
+              isDark,
+            ),
+          ),
+          const SliverPadding(padding: EdgeInsets.only(bottom: 16.0)),
         ],
-      ),
-    );
+      );
+    } else {
+      return SliverToBoxAdapter(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildBismillah(isDark),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: _buildRichTextContent(
+                context,
+                chapters,
+                bookmarkState,
+                errorState,
+                isDark,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
   }
 
   Widget _buildRichTextContent(
@@ -1663,7 +1682,7 @@ class _SurahScreenState extends State<SurahScreen> {
     return null;
   }
 
-  Widget _buildSingleLineContent(
+  Widget _buildSingleLineContentSliver(
     BuildContext context,
     List<Verse> chapters,
     BookmarkState bookmarkState,
@@ -1680,9 +1699,13 @@ class _SurahScreenState extends State<SurahScreen> {
     final bookmarkedVerseNumbers = verseStates.bookmarkedVerses;
     final errorVerseIds = verseStates.errorVerses;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: chapters.map((aya) {
+    // Performance Optimization: Use SliverList.builder instead of Column+map\n    // to preserve list virtualization. This prevents O(N) layout time for long Surahs\n    // and significantly reduces memory usage by lazily rendering only visible verses.\n    // Performance Optimization: Use SliverList.builder instead of Column+map
+    // to preserve list virtualization. This prevents O(N) layout time for long Surahs
+    // and significantly reduces memory usage by lazily rendering only visible verses.
+    return SliverList.builder(
+      itemCount: chapters.length,
+      itemBuilder: (context, index) {
+        final aya = chapters[index];
         bool isBookmarked = bookmarkedVerseNumbers.contains(aya.verseNumber);
         bool isRecitationError = errorVerseIds.contains(aya.verseNumber);
 
@@ -1822,7 +1845,7 @@ class _SurahScreenState extends State<SurahScreen> {
             ),
           ),
         );
-      }).toList(),
+      },
     );
   }
 }


### PR DESCRIPTION
💡 **What:** Replaced the mapped `Column` inside `SliverToBoxAdapter` with a `SliverList.builder` using `SliverMainAxisGroup` for `_buildSurahList`'s single-line view.
🎯 **Why:** Rendering all verses simultaneously (up to 286 widgets + sub-widgets for Al-Baqarah) inside a Column broke scroll virtualization, causing massive layout thrashing and high peak memory. 
📊 **Impact:** Drastically improves initial load time, frame rendering times, and overall scroll performance for long Surahs. O(N) sync processing reduced to lazy evaluation.
🔬 **Measurement:** Launch application and navigate to Al-Baqarah. Ensure View Mode is "Single Line". Observe layout phase drop and smooth 60fps scrolling. Tests pass via `flutter test`.

---
*PR created automatically by Jules for task [3199149673736828076](https://jules.google.com/task/3199149673736828076) started by @moatazhamada*