### PR TITLE
🎨 Palette: Add tooltips to audio player control buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Accessibility Tooltips on IconButtons]
+**Learning:** Flutter `IconButton` components must include `tooltip` arguments when no explicit textual labels are present, so that accessibility systems (like screen readers) and hover actions accurately inform users of their functionality. Relying purely on surrounding `Semantics` elements can be insufficient or cause nested announcements, while a tooltip directly sets the underlying semantic label on the button correctly and consistently.
+**Action:** When creating or fixing `IconButton`s containing solely an icon, ensure the `tooltip` property is defined with localized strings to satisfy both hover and semantic requirements.

--- a/lib/localization/ar_eg/ar_eg_translations.dart
+++ b/lib/localization/ar_eg/ar_eg_translations.dart
@@ -282,4 +282,6 @@ final Map<String, String> arEg = {
   'lbl_slow': 'بطيء',
   'lbl_normal': 'عادي',
   'lbl_fast': 'سريع',
+  'lbl_rewind_10': 'إرجاع 10 ثواني',
+  'lbl_forward_10': 'تقديم 10 ثواني',
 };

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -285,4 +285,6 @@ final Map<String, String> enUs = {
   'lbl_slow': 'Slow',
   'lbl_normal': 'Normal',
   'lbl_fast': 'Fast',
+  'lbl_rewind_10': 'Rewind 10 seconds',
+  'lbl_forward_10': 'Forward 10 seconds',
 };

--- a/lib/presentation/audio_player/audio_player_screen.dart
+++ b/lib/presentation/audio_player/audio_player_screen.dart
@@ -381,6 +381,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
       children: [
         IconButton(
           icon: const Icon(Icons.replay_10, size: 32),
+          tooltip: 'lbl_rewind_10'.tr,
           onPressed: () {
             _handler.seekRelative(const Duration(seconds: -10));
             setState(() {});
@@ -408,6 +409,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
                     color: Colors.white,
                     size: 36,
                   ),
+                  tooltip: _handler.isPlaying ? 'lbl_pause'.tr : 'lbl_play'.tr,
                   onPressed: () {
                     if (_handler.isPlaying) {
                       _handler.pause();
@@ -423,6 +425,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
         const SizedBox(width: 24),
         IconButton(
           icon: const Icon(Icons.forward_10, size: 32),
+          tooltip: 'lbl_forward_10'.tr,
           onPressed: () {
             _handler.seekRelative(const Duration(seconds: 10));
             setState(() {});


### PR DESCRIPTION
💡 What: Added localized tooltips to the playback control buttons in the audio player screen.
🎯 Why: Icon-only buttons lacked semantic labels and hover text, making them difficult for screen reader users and those relying on pointer interactions to understand.
📸 Before/After: Visual tooltips now display on hover, and semantic labels are properly passed to screen readers.
♿ Accessibility: Ensures that playback controls are fully accessible via screen readers and keyboard navigation.

---
*PR created automatically by Jules for task [5204323860420648415](https://jules.google.com/task/5204323860420648415) started by @moatazhamada*