### PR TITLE
🎨 Palette: Add tooltips to IconButtons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - [Tooltip Mapping]
+**Learning:** In Flutter, adding a `tooltip` property directly to an `IconButton` implicitly provides the semantic label for screen readers. Explicit `Semantics` wrapper widgets around `IconButton`s are often redundant if a `tooltip` is used, though not harmful.
+**Action:** When adding accessibility to `IconButton` widgets, prefer using the `tooltip` property to provide both hover text for sighted users and semantic labels for screen readers in a single step, reducing widget tree nesting.

--- a/lib/presentation/bookmarks/bookmarks_screen.dart
+++ b/lib/presentation/bookmarks/bookmarks_screen.dart
@@ -21,6 +21,7 @@ class BookmarksScreen extends StatelessWidget {
           child: IconButton(
             icon: const Icon(Icons.arrow_back),
             onPressed: () => NavigatorService.goBack(),
+            tooltip: 'lbl_back'.tr,
           ),
         ),
         centerTitle: true,
@@ -215,6 +216,7 @@ class BookmarksScreen extends StatelessWidget {
                                       Icons.delete_outline,
                                       color: Colors.redAccent,
                                     ),
+                                    tooltip: 'lbl_delete'.tr,
                                     onPressed: () {
                                       bookmarkBloc.add(
                                         RemoveBookmarkEvent(

--- a/lib/presentation/recitation_error/recitation_error_screen.dart
+++ b/lib/presentation/recitation_error/recitation_error_screen.dart
@@ -15,9 +15,14 @@ class RecitationErrorScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => NavigatorService.goBack(),
+        leading: Semantics(
+          button: true,
+          label: 'lbl_back'.tr,
+          child: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => NavigatorService.goBack(),
+            tooltip: 'lbl_back'.tr,
+          ),
         ),
         centerTitle: true,
         title: Text(
@@ -182,19 +187,24 @@ class RecitationErrorScreen extends StatelessWidget {
                                   ],
                                 ),
                               ),
-                              IconButton(
-                                icon: const Icon(
-                                  Icons.check_circle_outline,
-                                  color: Colors.green,
+                              Semantics(
+                                button: true,
+                                label: 'msg_unmark_practice'.tr,
+                                child: IconButton(
+                                  icon: const Icon(
+                                    Icons.check_circle_outline,
+                                    color: Colors.green,
+                                  ),
+                                  tooltip: 'msg_unmark_practice'.tr,
+                                  onPressed: () {
+                                    context.read<RecitationErrorBloc>().add(
+                                      RemoveRecitationErrorEvent(
+                                        error.surahId,
+                                        error.verseId,
+                                      ),
+                                    );
+                                  },
                                 ),
-                                onPressed: () {
-                                  context.read<RecitationErrorBloc>().add(
-                                    RemoveRecitationErrorEvent(
-                                      error.surahId,
-                                      error.verseId,
-                                    ),
-                                  );
-                                },
                               ),
                             ],
                           ),

--- a/lib/presentation/search/search_screen.dart
+++ b/lib/presentation/search/search_screen.dart
@@ -38,6 +38,7 @@ class _SearchScreenState extends State<SearchScreen> {
             child: IconButton(
               icon: const Icon(Icons.arrow_back, color: Colors.white),
               onPressed: () => NavigatorService.goBack(),
+              tooltip: 'lbl_back'.tr,
             ),
           ),
           title: Semantics(

--- a/lib/presentation/surah_screen/surah_screen.dart
+++ b/lib/presentation/surah_screen/surah_screen.dart
@@ -582,12 +582,17 @@ class _SurahScreenState extends State<SurahScreen> {
                             ),
                           ),
                         ),
-                        IconButton(
-                          icon: Icon(
-                            Icons.close,
-                            color: isDark ? Colors.white70 : Colors.black54,
+                        Semantics(
+                          button: true,
+                          label: 'lbl_close'.tr,
+                          child: IconButton(
+                            icon: Icon(
+                              Icons.close,
+                              color: isDark ? Colors.white70 : Colors.black54,
+                            ),
+                            onPressed: () => Navigator.pop(context),
+                            tooltip: 'lbl_close'.tr,
                           ),
-                          onPressed: () => Navigator.pop(context),
                         ),
                       ],
                     ),
@@ -782,6 +787,7 @@ class _SurahScreenState extends State<SurahScreen> {
         child: IconButton(
           icon: const Icon(Icons.arrow_back_outlined, color: Colors.white),
           onPressed: () => NavigatorService.goBack(),
+          tooltip: 'lbl_back'.tr,
         ),
       ),
       actions: [


### PR DESCRIPTION
💡 What: Added tooltips to icon buttons across multiple screens (`bookmarks_screen`, `search_screen`, `surah_screen`, `recitation_error_screen`).
🎯 Why: To provide sighted users with hover/long-press visual feedback and improve general accessibility.
♿ Accessibility: Tooltips in Flutter act as implicit semantic labels. These tooltips directly use the existing localized `.tr` strings to ensure full i18n support.

---
*PR created automatically by Jules for task [10415357855232627830](https://jules.google.com/task/10415357855232627830) started by @moatazhamada*