### PR TITLE
Add Google Play Store download link to demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,6 +290,12 @@
       </div>
       <div class="download-grid">
         <div class="download-card">
+          <h3>Google Play Store</h3>
+          <p>Store release (v3.3.0 rolling out / v3.1.0)</p>
+          <a href="https://play.google.com/store/apps/details?id=com.hafiz.app.hafiz_app" class="btn btn-primary" style="width:100%;justify-content:center" target="_blank">Get it on Google Play</a>
+          <p class="file-size">Public release</p>
+        </div>
+        <div class="download-card">
           <h3>Google Play</h3>
           <p>Internal testing track (v3.3.0+26)</p>
           <a href="https://play.google.com/apps/internaltest/4701498538025179659" class="btn btn-primary" style="width:100%;justify-content:center" target="_blank">Join Internal Testing</a>


### PR DESCRIPTION
Add the public Google Play Store link as the first option in the download section of `index.html`. This ensures the public release link is prominent for the hackathon demo page.

---
*PR created automatically by Jules for task [12390895455660753624](https://jules.google.com/task/12390895455660753624) started by @moatazhamada*